### PR TITLE
fix: resend event, Swagger decorators, paid checkout 501, MongoDB URI config

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -38,11 +38,12 @@ import { CourseAnalyticsModule } from './course-analytics/course-analytics.modul
         limit: 10,
       },
     ]),
-    // MongoDB connection
+    // MongoDB connection — reads mongoUri from app.config.ts which maps MONGO_URI
     MongooseModule.forRootAsync({
-      useFactory: () => ({
-        uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/chainverse',
+      useFactory: (config: ConfigService) => ({
+        uri: config.get<string>('mongoUri'),
       }),
+      inject: [ConfigService],
     }),
     WorkerModule,
     MetricsModule,

--- a/src/events/event-names.ts
+++ b/src/events/event-names.ts
@@ -10,6 +10,9 @@ export const DomainEvents = {
   /** Fired after a student is enrolled in a course. */
   STUDENT_ENROLLED: 'student.enrolled',
 
+  /** Fired when a student requests a verification email resend (distinct from initial registration). */
+  VERIFICATION_EMAIL_RESENT: 'student.verification-email-resent',
+
   /** Fired after an admin/moderator approves a financial-aid application. */
   FINANCIAL_AID_APPROVED: 'financial-aid.approved',
 

--- a/src/student-auth/student-auth.controller.ts
+++ b/src/student-auth/student-auth.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Post, Req } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { StudentAuthService } from './student-auth.service';
 import { CreateStudentDto } from './dto/create-student.dto';
@@ -11,31 +12,49 @@ import { RefreshTokenDto } from './dto/refresh-token.dto';
 
 // Auth endpoints are more sensitive to brute-force: tighten to 10 req/min
 @Throttle({ default: { limit: 10, ttl: 60_000 } })
+@ApiTags('Student Auth')
 @Controller('student')
 export class StudentAuthController {
   constructor(private readonly studentAuthService: StudentAuthService) {}
 
   @Post('create')
+  @ApiOperation({ summary: 'Register a new student account' })
+  @ApiResponse({ status: 201, description: 'Account created successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid input or missing fields' })
+  @ApiResponse({ status: 409, description: 'Email already registered' })
   create(@Body() dto: CreateStudentDto) {
     return this.studentAuthService.create(dto);
   }
 
   @Post('verify-email')
+  @ApiOperation({ summary: 'Verify student email with token' })
+  @ApiResponse({ status: 200, description: 'Email verified successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token' })
   verifyEmail(@Body() dto: VerifyEmailDto) {
     return this.studentAuthService.verifyEmail(dto);
   }
 
   @Post('resend-verification-email')
+  @ApiOperation({ summary: 'Resend email verification link' })
+  @ApiResponse({ status: 200, description: 'Verification email sent if account exists' })
+  @ApiResponse({ status: 400, description: 'Email already verified or cooldown active' })
   resendVerificationEmail(@Body() dto: ResendVerificationEmailDto) {
     return this.studentAuthService.resendVerificationEmail(dto);
   }
 
   @Post('login')
+  @ApiOperation({ summary: 'Authenticate a student and receive tokens' })
+  @ApiResponse({ status: 200, description: 'Login successful, returns access and refresh tokens' })
+  @ApiResponse({ status: 400, description: 'Missing credentials' })
+  @ApiResponse({ status: 401, description: 'Invalid credentials or unverified email' })
   login(@Body() dto: LoginStudentDto) {
     return this.studentAuthService.login(dto);
   }
 
   @Post('forget/password')
+  @ApiOperation({ summary: 'Request a password reset link' })
+  @ApiResponse({ status: 200, description: 'Reset link sent if account exists' })
+  @ApiResponse({ status: 400, description: 'Missing or invalid email' })
   forgetPassword(@Body() dto: ForgetPasswordDto, @Req() req: Request) {
     return this.studentAuthService.forgetPassword(
       dto,
@@ -45,6 +64,9 @@ export class StudentAuthController {
   }
 
   @Post('reset/password')
+  @ApiOperation({ summary: 'Reset password using a valid reset token' })
+  @ApiResponse({ status: 200, description: 'Password reset successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token, or weak password' })
   resetPassword(@Body() dto: ResetPasswordDto, @Req() req: Request) {
     return this.studentAuthService.resetPassword(
       dto,
@@ -54,11 +76,17 @@ export class StudentAuthController {
   }
 
   @Post('refresh-token')
+  @ApiOperation({ summary: 'Rotate refresh token and get a new token pair' })
+  @ApiResponse({ status: 200, description: 'New access and refresh tokens issued' })
+  @ApiResponse({ status: 401, description: 'Invalid or revoked refresh token' })
   refreshToken(@Body() dto: RefreshTokenDto) {
     return this.studentAuthService.refreshToken(dto);
   }
 
   @Post('logout')
+  @ApiOperation({ summary: 'Invalidate the current refresh token' })
+  @ApiResponse({ status: 200, description: 'Logged out successfully' })
+  @ApiResponse({ status: 400, description: 'Missing refresh token' })
   logout(@Body() dto: RefreshTokenDto) {
     return this.studentAuthService.logout(dto);
   }

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -327,7 +327,7 @@ export class StudentAuthService {
     await student.save();
 
     this.eventEmitter.emit(
-      DomainEvents.STUDENT_REGISTERED,
+      DomainEvents.VERIFICATION_EMAIL_RESENT,
       Object.assign(new StudentRegisteredPayload(), {
         studentId: student.id,
         email: student.email,

--- a/src/student-enrollment/student-enrollment.service.ts
+++ b/src/student-enrollment/student-enrollment.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
+  NotImplementedException,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
@@ -112,16 +113,22 @@ export class StudentEnrollmentService {
           .findOne({ studentId, courseId: item.courseId })
           .exec();
         if (existing) {
-          // If already enrolled, just skip and remove from cart
           await this.cartItemModel.findByIdAndDelete(item._id).exec();
           continue;
+        }
+
+        // Paid courses require a real payment step — not yet implemented
+        if (course.price > 0) {
+          throw new NotImplementedException(
+            'Payment processing is not yet implemented. Paid course enrollment is unavailable.',
+          );
         }
 
         const enrollment = new this.enrollmentModel({
           studentId,
           courseId: item.courseId,
-          type: course.price > 0 ? 'paid' : 'free',
-          amountPaid: course.price,
+          type: 'free',
+          amountPaid: 0,
           status: 'completed',
           paymentMethod,
         });


### PR DESCRIPTION


- closes #339: emit VERIFICATION_EMAIL_RESENT instead of STUDENT_REGISTERED on resend
- closes #340: add @ApiOperation and @ApiResponse decorators to all StudentAuthController endpoints
- closes #341: block paid course checkout with 501 NotImplemented until payment is integrated
- closes #342: use ConfigService to read mongoUri from app.config.ts instead of raw process.env.MONGODB_URI


