### PR TITLE
feat: register missing modules in AppModule (#350, #355, #352, #351)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,7 @@ import { CourseAnalyticsModule } from './course-analytics/course-analytics.modul
 import { GamificationPointsModule } from './gamification-points/gamification-points.module';
 import { FaqManagementModule } from './faq-management/faq-management.module';
 import { GoogleAuthModule } from './google-auth/google-auth.module';
+import { PointsModule } from './points/points.module';
 
 @Module({
   imports: [
@@ -83,6 +84,8 @@ import { GoogleAuthModule } from './google-auth/google-auth.module';
     FaqManagementModule,
     // Google Auth
     GoogleAuthModule,
+    // Points
+    PointsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { StudentEnrollmentModule } from './student-enrollment/student-enrollment
 import { CourseAnalyticsModule } from './course-analytics/course-analytics.module';
 import { GamificationPointsModule } from './gamification-points/gamification-points.module';
 import { FaqManagementModule } from './faq-management/faq-management.module';
+import { GoogleAuthModule } from './google-auth/google-auth.module';
 
 @Module({
   imports: [
@@ -80,6 +81,8 @@ import { FaqManagementModule } from './faq-management/faq-management.module';
     GamificationPointsModule,
     // FAQ
     FaqManagementModule,
+    // Google Auth
+    GoogleAuthModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { StudentSavedCoursesModule } from './student-saved-courses/student-saved
 import { StudentCartModule } from './student-cart/student-cart.module';
 import { StudentEnrollmentModule } from './student-enrollment/student-enrollment.module';
 import { CourseAnalyticsModule } from './course-analytics/course-analytics.module';
+import { GamificationPointsModule } from './gamification-points/gamification-points.module';
 
 @Module({
   imports: [
@@ -74,6 +75,8 @@ import { CourseAnalyticsModule } from './course-analytics/course-analytics.modul
     StudentEnrollmentModule,
     // Analytics
     CourseAnalyticsModule,
+    // Gamification
+    GamificationPointsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { StudentCartModule } from './student-cart/student-cart.module';
 import { StudentEnrollmentModule } from './student-enrollment/student-enrollment.module';
 import { CourseAnalyticsModule } from './course-analytics/course-analytics.module';
 import { GamificationPointsModule } from './gamification-points/gamification-points.module';
+import { FaqManagementModule } from './faq-management/faq-management.module';
 
 @Module({
   imports: [
@@ -77,6 +78,8 @@ import { GamificationPointsModule } from './gamification-points/gamification-poi
     CourseAnalyticsModule,
     // Gamification
     GamificationPointsModule,
+    // FAQ
+    FaqManagementModule,
   ],
   controllers: [AppController],
   providers: [


### PR DESCRIPTION
## Summary

Four fully-implemented NestJS modules were missing from `AppModule` imports, causing their routes to return 404. This PR registers each one in a dedicated commit.

- Register `GamificationPointsModule` — makes gamification-points routes reachable
- Register `FaqManagementModule` — makes FAQ routes reachable
- Register `GoogleAuthModule` — makes Google OAuth routes reachable
- Register `PointsModule` — makes points routes reachable

## Changes

Only `src/app.module.ts` is modified — one import statement and one entry in the `imports` array added per module.

## Issues

Closes #350
Closes #355
Closes #352
Closes #351