### PR TITLE
fix: resolve N+1 queries, pagination, and rating uniqueness (#378 #380 #381 #382)

### DIFF
--- a/src/admin-course/admin-course.controller.ts
+++ b/src/admin-course/admin-course.controller.ts
@@ -29,18 +29,18 @@ export class AdminCourseController {
   constructor(private readonly adminCourseService: AdminCourseService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get all courses with optional filters' })
+  @ApiOperation({ summary: 'Get all courses with optional filters and pagination' })
   findAll(
     @Query('status') status?: string,
     @Query('category') category?: string,
     @Query('limit') limit?: number,
-    @Query('skip') skip?: number,
+    @Query('page') page?: number,
   ) {
     return this.adminCourseService.findAll({
       status,
       category,
       limit: limit ? parseInt(String(limit), 10) : undefined,
-      skip: skip ? parseInt(String(skip), 10) : undefined,
+      page: page ? parseInt(String(page), 10) : undefined,
     });
   }
 

--- a/src/admin-course/admin-course.service.ts
+++ b/src/admin-course/admin-course.service.ts
@@ -54,35 +54,41 @@ export class AdminCourseService {
   }
 
   /**
-   * Find all courses with optional filters
+   * Find all courses with optional filters and pagination
    */
   async findAll(filters?: {
     status?: string;
     category?: string;
     tutorId?: string;
     limit?: number;
-    skip?: number;
+    page?: number;
   }) {
     const query: Record<string, unknown> = {};
 
-    if (filters?.status) {
-      query.status = filters.status;
-    }
-    if (filters?.category) {
-      query.category = filters.category;
-    }
-    if (filters?.tutorId) {
-      query.tutorId = filters.tutorId;
-    }
+    if (filters?.status) query.status = filters.status;
+    if (filters?.category) query.category = filters.category;
+    if (filters?.tutorId) query.tutorId = filters.tutorId;
 
-    const courses = await this.courseModel
-      .find(query)
-      .sort({ createdAt: -1 })
-      .limit(filters?.limit || 100)
-      .skip(filters?.skip || 0)
-      .exec();
+    const limit = Math.min(filters?.limit || 10, 50);
+    const page = Math.max(filters?.page || 1, 1);
+    const skip = (page - 1) * limit;
 
-    return courses.map((c) => this.sanitizeCourse(c));
+    const [courses, total] = await Promise.all([
+      this.courseModel
+        .find(query)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .exec(),
+      this.courseModel.countDocuments(query).exec(),
+    ]);
+
+    return {
+      total,
+      page,
+      limit,
+      data: courses.map((c) => this.sanitizeCourse(c)),
+    };
   }
 
   /**

--- a/src/student-cart/student-cart.service.ts
+++ b/src/student-cart/student-cart.service.ts
@@ -62,24 +62,21 @@ export class StudentCartService {
   }> {
     const items = await this.cartItemModel.find({ studentId }).exec();
 
-    // Fetch course details for each cart item
-    const itemsWithDetails = await Promise.all(
-      items.map(async (item) => {
-        const course = await this.courseModel.findById(item.courseId).exec();
-        return {
-          cartItem: item,
-          course: course
-            ? {
-                id: course.id,
-                title: course.title,
-                price: course.price,
-                thumbnailUrl: course.thumbnailUrl,
-                tutorName: course.tutorName,
-              }
-            : null,
-        };
-      }),
+    const courseIds = items.map((i) => i.courseId);
+    const courses = await this.courseModel
+      .find({ _id: { $in: courseIds } })
+      .exec();
+    const courseMap = new Map(
+      courses.map((c) => [
+        c.id,
+        { id: c.id, title: c.title, price: c.price, thumbnailUrl: c.thumbnailUrl, tutorName: c.tutorName },
+      ]),
     );
+
+    const itemsWithDetails = items.map((item) => ({
+      cartItem: item,
+      course: courseMap.get(item.courseId) ?? null,
+    }));
 
     const validItems = itemsWithDetails.filter((i) => i.course !== null);
     const totalPrice = validItems.reduce((sum, item) => {

--- a/src/student-enrollment/student-enrollment.service.ts
+++ b/src/student-enrollment/student-enrollment.service.ts
@@ -171,23 +171,26 @@ export class StudentEnrollmentService {
         id: string;
         title: string;
         description: string;
-        thumbnailUrl: string;
+        thumbnailUrl: string | null;
         tutorName: string;
         progress?: number;
       };
     }>
   > {
     const enrollments = await this.enrollmentModel.find({ studentId }).exec();
+    if (enrollments.length === 0) return [];
 
-    const coursesWithEnrollment = await Promise.all(
-      enrollments.map(async (enrollment) => {
-        const course = await this.courseModel
-          .findById(enrollment.courseId)
-          .exec();
-        if (!course) {
-          return null;
-        }
-        return {
+    const courseIds = enrollments.map((e) => e.courseId);
+    const courses = await this.courseModel
+      .find({ _id: { $in: courseIds } })
+      .exec();
+    const courseMap = new Map(courses.map((c) => [c.id, c]));
+
+    return enrollments.reduce(
+      (acc, enrollment) => {
+        const course = courseMap.get(enrollment.courseId);
+        if (!course) return acc;
+        acc.push({
           enrollment,
           course: {
             id: course.id,
@@ -197,21 +200,21 @@ export class StudentEnrollmentService {
             tutorName: course.tutorName,
             progress: 0, // TODO: Implement progress tracking
           },
+        });
+        return acc;
+      },
+      [] as Array<{
+        enrollment: EnrollmentDocument;
+        course: {
+          id: string;
+          title: string;
+          description: string;
+          thumbnailUrl: string | null;
+          tutorName: string;
+          progress?: number;
         };
-      }),
+      }>,
     );
-
-    return coursesWithEnrollment.filter((c) => c !== null) as Array<{
-      enrollment: EnrollmentDocument;
-      course: {
-        id: string;
-        title: string;
-        description: string;
-        thumbnailUrl: string;
-        tutorName: string;
-        progress?: number;
-      };
-    }>;
   }
 
   async isEnrolled(studentId: string, courseId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

Fixes four issues assigned to @nanaf6203-bit.

---

### #382 — CourseRating: uniqueness check + compound index
- Service already throws `ConflictException` when a student tries to rate the same course twice
- Schema already has `{ courseId: 1, studentId: 1 }` unique compound index

### #381 — `getMyCourses()`: replace N+1 queries with `$in`
- Replaced `Promise.all` + individual `findById` calls with a single `courseModel.find({ _id: { $in: courseIds } })` query
- Results mapped via a `Map` for O(1) lookup

### #380 — `getCart()`: replace N+1 queries with `$in`
- Same pattern: replaced per-item `findById` with one `courseModel.find({ _id: { $in: courseIds } })` call
- Results mapped via a `Map` for O(1) lookup

### #378 — `GET /admin/courses`: add page-based pagination
- Added `page` query param (replaces raw `skip`)
- Enforced max `limit` of 50 (default 10)
- Response now returns `{ total, page, limit, data }`

---

Closes #378
Closes #380
Closes #381
Closes #382