### PR TITLE
fix: normalize password routes and wrap isEnrolled in JSON

### DIFF
--- a/src/student-auth/student-auth.controller.ts
+++ b/src/student-auth/student-auth.controller.ts
@@ -63,7 +63,7 @@ export class StudentAuthController {
     return this.studentAuthService.login(dto);
   }
 
-  @Post('forget/password')
+  @Post('forgot-password')
   @ApiOperation({ summary: 'Request a password reset link' })
   @ApiResponse({
     status: 200,
@@ -78,7 +78,7 @@ export class StudentAuthController {
     );
   }
 
-  @Post('reset/password')
+  @Post('reset-password')
   @ApiOperation({ summary: 'Reset password using a valid reset token' })
   @ApiResponse({ status: 200, description: 'Password reset successfully' })
   @ApiResponse({

--- a/src/student-enrollment/student-enrollment.controller.ts
+++ b/src/student-enrollment/student-enrollment.controller.ts
@@ -45,10 +45,11 @@ export class StudentEnrollmentController {
 
   @ApiOperation({ summary: 'Check if student is enrolled in a course' })
   @Get('is-enrolled/:courseId')
-  isEnrolled(
+  async isEnrolled(
     @Req() req: { user: { id: string } },
     @Param('courseId') courseId: string,
   ) {
-    return this.service.isEnrolled(req.user.id, courseId);
+    const enrolled = await this.service.isEnrolled(req.user.id, courseId);
+    return { isEnrolled: enrolled };
   }
 }

--- a/src/tutor/tutor.controller.ts
+++ b/src/tutor/tutor.controller.ts
@@ -38,7 +38,7 @@ export class TutorController {
     return this.tutorService.verifyEmail(dto);
   }
 
-  @Post('forget/password')
+  @Post('forgot-password')
   forgetPassword(@Body() dto: ForgetTutorPasswordDto, @Req() req: Request) {
     return this.tutorService.forgetPassword(
       dto,
@@ -47,7 +47,7 @@ export class TutorController {
     );
   }
 
-  @Post('reset/password')
+  @Post('reset-password')
   resetPassword(@Body() dto: ResetTutorPasswordDto, @Req() req: Request) {
     return this.tutorService.resetPassword(
       dto,


### PR DESCRIPTION
## Summary

Closes #375,
Close #376 
Closes #377 
Close  #379 

## Changes

- **#375** `student-auth` & `tutor`: `POST forget/password` → `POST forgot-password`
- **#376** `student-auth` & `tutor`: `POST reset/password` → `POST reset-password`
- **#377** `GET is-enrolled/:courseId` now returns `{ isEnrolled: boolean }` instead of a raw boolean
- **#379** `course-discovery.service.ts` already uses MongoDB `$text` operator — no change needed