### PR TITLE
Register AdminAuthModule in AppModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { EmailModule } from './email/email.module';
 
 // Course modules
 import { AdminCourseModule } from './admin-course/admin-course.module';
+import { AdminAuthModule } from './admin-auth/admin-auth.module';
 import { TutorModule } from './tutor/tutor.module';
 import { TutorCourseModule } from './tutor-course/tutor-course.module';
 import { CourseDiscoveryModule } from './course-discovery/course-discovery.module';
@@ -72,6 +73,7 @@ import { OrganizationMemberModule } from './organization-member/organization-mem
     // Tutor modules
     TutorModule,
     // Course modules
+    AdminAuthModule,
     AdminCourseModule,
     TutorCourseModule,
     CourseDiscoveryModule,


### PR DESCRIPTION
## Description  
The admin authentication and management routes were returning 404 Not Found because the AdminAuthModule was implemented but not registered in the root AppModule.

## Related Issues  
Closes: #349 

## Changes Made  
- [x] Enables all routes defined within AdminAuthController
- [x] Resolves the issue where admin login and management functionality was unreachable. 

## Checklist  
- [x] My code follows the project's coding style.  
- [x] I have tested these changes locally.  
