### PR TITLE
Fix/docker resource limits dockerfile ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Prevent sensitive and unnecessary files from being copied into Docker image
+node_modules
+dist
+coverage
+.env
+.env.*
+*.log
+.git
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["node", "dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,11 @@ services:
       mongo:
         condition: service_healthy
 
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+
 volumes:
   mongo_data:


### PR DESCRIPTION
## Description
This PR addresses critical Docker configuration gaps that were preventing proper containerization, risking secret leakage, and allowing uncontrolled resource consumption. It introduces a `.dockerignore` file, a working `Dockerfile`, and resource limits in `docker-compose.yml` to ensure secure, efficient, and production-ready container deployment.

## Related Issues
Closes #455
Closes #453
Closes #407

## Changes Made
- Added `.dockerignore` to exclude `node_modules`, `.env`, `coverage`, `dist`, logs, Git metadata, and test directories from Docker build context
- Created a production-ready `Dockerfile` using `node:20-alpine` that installs dependencies, runs build, and sets the proper entry point
- Added resource constraints to `docker-compose.yml` (CPU limit: 1.0 cores, Memory limit: 512MB) for the app service to prevent resource starvation on the host

## How to Test
1. Build the Docker image:
   ```bash
   docker build -t app-name .
   ```
2. Verify that .dockerignore works (ensure node_modules and .env are not copied):
   ```bash
       docker run --rm app-name ls -la
   ```
        
3. Run with Compose and confirm resource limits:
    ```bash
        docker-compose up -d
        docker inspect <container-id> | grep -A 5 "Resources"
    ```
4. Test the containerized app:
    ```bash
        curl http://localhost:3000
    ```

## Screenshots (if applicable)
  N/A — Infrastructure and configuration changes only.

## Checklist
- My code follows the project's coding style.
- I have tested these changes locally.


Closes #455
Closes #453
Closes #407 