### PR TITLE
Fix/docker security and performance redis nonroot multistage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+
+# --- Build Stage ---
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# --- Runner Stage ---
+FROM node:20-alpine AS runner
+WORKDIR /app
+# Create non-root user and group
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package*.json ./
+USER appuser
+EXPOSE 3000
+CMD ["node", "dist/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 
+
 # --- Build Stage ---
 FROM node:20-alpine AS builder
 WORKDIR /app
@@ -12,9 +13,9 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 # Create non-root user and group
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-COPY --from=builder /app/node_modules ./node_modules
+COPY package*.json ./
+RUN npm ci --only=production
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package*.json ./
 USER appuser
 EXPOSE 3000
 CMD ["node", "dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,17 @@ services:
       retries: 5
       start_period: 20s
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   app:
     build: .
     restart: unless-stopped
@@ -24,6 +35,8 @@ services:
       - .env
     depends_on:
       mongo:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
 volumes:

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,12 @@ async function bootstrap() {
 
   app.useLogger(app.get(Logger));
 
+
+  // Body size limits for security (#405)
+  const express = await import('express');
+  app.use(express.json({ limit: '1mb' }));
+  app.use(express.urlencoded({ limit: '1mb', extended: true }));
+
   // Compress all responses (#416)
   app.use(compression());
 


### PR DESCRIPTION
## Description  
This PR addresses multiple Docker security and performance issues, as well as a missing request body size limit. The Dockerfile has been refactored to a multi‑stage build, removing unnecessary devDependencies and running the container as a non‑root user for better security. The `docker-compose.yml` now includes a Redis service with a health check, ensuring rate limiting uses persistent storage instead of falling back to in‑memory. Finally, an Express JSON body size limit has been added to prevent large‑payload memory exhaustion attacks.

## Related Issues  
- Closes #457  
- Closes #456  
- Closes #454  
- Closes #405  

## Changes Made  
- [x] Added Redis service to `docker-compose.yml` with health check and updated app `depends_on` to require a healthy Redis.  
- [x] Converted `Dockerfile` to multi‑stage build: `builder` stage compiles TypeScript, `runner` stage copies only production dependencies and compiled output.  
- [x] Added non‑root user (`appuser`) in the runner stage of `Dockerfile` and switched to it before starting the app.  
- [x] Configured Express JSON and URL‑encoded body parsers in `main.ts` with a `1mb` limit.  

## How to Test  
1. **Redis in Docker Compose**  
   - Run `docker-compose up -d`  
   - Verify the Redis container starts healthy: `docker-compose ps` (status should be `healthy`)  
   - Check that the app connects to Redis (e.g., by viewing logs for any connection errors)  

2. **Non‑root user & multi‑stage build**  
   - Build the image: `docker build -t app .`  
   - Run a temporary container: `docker run --rm -it app id` – the output should show `uid=1000(appuser)` not `root`  
   - Check image size: `docker images app` – it should be significantly smaller than before (no dev dependencies)  

3. **Body size limit**  
   - Run the app locally or in Docker  
   - Send a POST request with a JSON payload larger than 1MB (e.g., using `curl -X POST -d '{"a":"...very long string..."}' -H "Content-Type: application/json" http://localhost:3000/some-endpoint`)  
   - The server should respond with `413 Payload Too Large` instead of processing the request or crashing  

## Screenshots (if applicable)  
None – configuration and security changes only.

## Checklist  
- [x] My code follows the project's coding style.  
- [x] I have tested these changes locally.  
- [x] Documentation has been updated where necessary (`.env.example` already includes `REDIS_URL`; no further docs needed).  

---

Closes #457  
Closes #456  
Closes #454  
Closes #405  