### PR TITLE
fix: register leaderboard module, fix health prefix exclusion, verify gamification routes

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import { SubscriptionPlanModule } from './subscription-plan/subscription-plan.mo
 import { OrganizationModule } from './organization/organization.module';
 import { OrganizationMemberModule } from './organization-member/organization-member.module';
 import { NotificationModule } from './notification/notification.module';
+import { CoursePerformanceLeaderboardModule } from './course-performance-leaderboard/course-performance-leaderboard.module';
 import { FinancialAidModule } from './financial-aid/financial-aid.module';
 import { StudentAuthModule } from './student-auth/student-auth.module';
 
@@ -103,6 +104,7 @@ import { StudentAuthModule } from './student-auth/student-auth.module';
     CourseAnalyticsModule,
     // Gamification
     GamificationPointsModule,
+    CoursePerformanceLeaderboardModule,
     // FAQ
     FaqManagementModule,
     // Google Auth

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,8 +22,8 @@ async function bootstrap() {
   // Compress all responses (#416)
   app.use(compression());
 
-  // Global API prefix (#415)
-  app.setGlobalPrefix('api');
+  // Global API prefix (#415) — exclude /health so Docker/LB probes work without prefix
+  app.setGlobalPrefix('api', { exclude: ['health', 'health/ready'] });
 
   // Security headers (X-Content-Type-Options, X-Frame-Options, HSTS, etc.)
   app.use(helmet());

--- a/test/gamification-smoke.e2e-spec.ts
+++ b/test/gamification-smoke.e2e-spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+
+/**
+ * Smoke tests for the gamification system.
+ * Verifies that BadgeModule, GamificationPointsModule, and
+ * CoursePerformanceLeaderboardModule are registered and their
+ * main GET endpoints respond (not 404).
+ */
+describe('Gamification smoke tests (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api', { exclude: ['health', 'health/ready'] });
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /api/badges responds (BadgeModule registered)', () =>
+    request(app.getHttpServer())
+      .get('/api/badges')
+      .expect((res) => {
+        expect(res.status).not.toBe(404);
+      }));
+
+  it('GET /api/gamification/points responds (GamificationPointsModule registered)', () =>
+    request(app.getHttpServer())
+      .get('/api/gamification/points')
+      .expect((res) => {
+        expect(res.status).not.toBe(404);
+      }));
+
+  it('GET /api/courses/performance-leaderboard responds (CoursePerformanceLeaderboardModule registered)', () =>
+    request(app.getHttpServer())
+      .get('/api/courses/performance-leaderboard')
+      .expect((res) => {
+        expect(res.status).not.toBe(404);
+      }));
+});


### PR DESCRIPTION
closes #471 
closes #479 
closes #480 
closes #481

## Summary

Addresses four bootstrap/module registration issues to ensure all routes are reachable and the app is production-ready.

---

## Task 1 — Request body size limit (`main.ts`)

**Status: Already implemented.**
`express.json({ limit: '1mb' })` and `express.urlencoded({ limit: '1mb' })` were already present in `main.ts`. No changes needed.

---

## Task 2 — GoogleAuthModule registration and OAuth routes

**Status: Already implemented.**
`GoogleAuthModule` is imported in `AppModule`. The module exposes:
- `POST /api/student/register/google-auth`
- `POST /api/student/login/google-auth`

The implementation uses a custom JWT flow (not passport-google-oauth20 redirect), which matches the existing codebase pattern. No changes needed.

---

## Task 3 — Health endpoint reachable without global prefix

**Change: `src/main.ts`**

The global prefix `api` was applied to all routes including `/health`, meaning Docker and load-balancer probes hitting `GET /health` would receive a 404.

Fixed by excluding health paths from the global prefix:
```ts
app.setGlobalPrefix('api', { exclude: ['health', 'health/ready'] });
```

The `HealthService` already verifies MongoDB connectivity via `connection.db.admin().ping()` — no changes needed there.

---

## Task 4 — Gamification modules registered + smoke tests

**Changes: `src/app.module.ts`, `test/gamification-smoke.e2e-spec.ts`**

`BadgeModule` and `GamificationPointsModule` were already registered in `AppModule`.  
`CoursePerformanceLeaderboardModule` was **missing** — added it.

Added `test/gamification-smoke.e2e-spec.ts` with three smoke tests that assert each module's main GET endpoint returns a non-404 response:
- `GET /api/badges`
- `GET /api/gamification/points`
- `GET /api/courses/performance-leaderboard`
```
