### PR TITLE
feat: add compression middleware to reduce response payload size

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,29 +13,27 @@ async function bootstrap() {
 
   app.useLogger(app.get(Logger));
 
-
-  // Body size limits for security (#405)
+  // Body size limits for security
   const express = await import('express');
   app.use(express.json({ limit: '1mb' }));
   app.use(express.urlencoded({ limit: '1mb', extended: true }));
 
-  // Compress all responses (#416)
-  app.use(compression());
+  // Compress responses larger than 1 KB with gzip level 6
+  app.use(compression({ level: 6, threshold: 1024 }));
 
-  // Global API prefix (#415)
+  // Global API prefix
   app.setGlobalPrefix('api');
 
-  // Security headers (X-Content-Type-Options, X-Frame-Options, HSTS, etc.)
+  // Security headers
   app.use(helmet());
 
-  // Configure CORS to restrict allowed origins
+  // Configure CORS
   app.enableCors({
     origin: process.env.ALLOWED_ORIGINS?.split(',') ?? ['http://localhost:3000'],
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });
 
-  // Validate and strip all incoming request bodies against DTO definitions
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -47,7 +45,6 @@ async function bootstrap() {
 
   app.useGlobalFilters(new AllExceptionsFilter());
 
-  // Only expose Swagger docs outside of production
   if (process.env.NODE_ENV !== 'production') {
     const config = new DocumentBuilder()
       .setTitle('ChainVerse API')


### PR DESCRIPTION
## Summary
- Apply `compression` middleware with `level: 6` (balanced speed/ratio) and `threshold: 1024` (only compress responses over 1 KB)
- Reduces payload size for large API responses (course listings, enrollment data)

Closes #473