### PR TITLE
feat: add global API prefix /api for all routes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,29 +13,27 @@ async function bootstrap() {
 
   app.useLogger(app.get(Logger));
 
-
-  // Body size limits for security (#405)
+  // Body size limits for security
   const express = await import('express');
   app.use(express.json({ limit: '1mb' }));
   app.use(express.urlencoded({ limit: '1mb', extended: true }));
 
-  // Compress all responses (#416)
+  // Compress all responses
   app.use(compression());
 
-  // Global API prefix (#415)
-  app.setGlobalPrefix('api');
+  // Global API prefix — exclude /health so load-balancers reach it without the prefix
+  app.setGlobalPrefix('api', { exclude: ['/health'] });
 
-  // Security headers (X-Content-Type-Options, X-Frame-Options, HSTS, etc.)
+  // Security headers
   app.use(helmet());
 
-  // Configure CORS to restrict allowed origins
+  // Configure CORS
   app.enableCors({
     origin: process.env.ALLOWED_ORIGINS?.split(',') ?? ['http://localhost:3000'],
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });
 
-  // Validate and strip all incoming request bodies against DTO definitions
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -47,7 +45,6 @@ async function bootstrap() {
 
   app.useGlobalFilters(new AllExceptionsFilter());
 
-  // Only expose Swagger docs outside of production
   if (process.env.NODE_ENV !== 'production') {
     const config = new DocumentBuilder()
       .setTitle('ChainVerse API')


### PR DESCRIPTION
## Summary
- Set global prefix `/api` for all routes via `app.setGlobalPrefix('api', { exclude: ['/health'] })`
- Excluding `/health` ensures load-balancer and container health checks reach the endpoint without the prefix
- Consistent with the Swagger base path shown in the README

Closes #475