### PR TITLE
fix: register session/org/faq modules, enable FAQ cache, and wire SMT…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.4",
         "compression": "^1.8.1",
+        "helmet": "^8.0.0",
         "joi": "^18.1.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^9.3.3",
@@ -6884,6 +6885,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/hookified": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,8 @@ import { MetricsModule } from './metrics/metrics.module';
 import { TracingModule } from './tracing/tracing.module';
 import { EmailModule } from './email/email.module';
 import { StellarModule } from './stellar/stellar.module';
+import { AppCacheModule } from './cache/app-cache.module';
+import { SessionModule } from './session/session.module';
 
 // Course modules
 import { AdminCourseModule } from './admin-course/admin-course.module';
@@ -72,6 +74,7 @@ import { StudentAuthModule } from './student-auth/student-auth.module';
       }),
       inject: [ConfigService],
     }),
+    AppCacheModule,
     // MongoDB connection — reads mongoUri from app.config.ts which maps MONGO_URI
     MongooseModule.forRootAsync({
       useFactory: (config: ConfigService) => ({
@@ -85,6 +88,7 @@ import { StudentAuthModule } from './student-auth/student-auth.module';
     MetricsModule,
     TracingModule,
     EmailModule,
+    SessionModule,
     // Tutor modules
     TutorModule,
     // Course modules

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -9,16 +9,17 @@ export class EmailService {
   private transporter: Transporter | null = null;
 
   constructor(private readonly configService: ConfigService) {
-    const host = this.configService.get<string>('smtpHost');
-    const port = this.configService.get<number>('smtpPort');
-    const user = this.configService.get<string>('emailUser');
-    const pass = this.configService.get<string>('emailPass');
+    const host = this.configService.get<string>('smtp.host');
+    const port = this.configService.get<number>('smtp.port');
+    const user = this.configService.get<string>('email.user');
+    const pass = this.configService.get<string>('email.pass');
+    const secure = this.configService.get<boolean>('smtp.secure') ?? false;
 
     if (host && port && user && pass) {
-      this.transporter = nodemailer.createTransporter({
+      this.transporter = nodemailer.createTransport({
         host,
         port,
-        secure: this.configService.get<boolean>('smtpSecure') ?? false,
+        secure,
         auth: { user, pass },
       });
     } else {
@@ -30,7 +31,7 @@ export class EmailService {
 
   async send(to: string, subject: string, text: string): Promise<void> {
     const from =
-      this.configService.get<string>('emailFrom') ??
+      this.configService.get<string>('email.from') ??
       'noreply@chainverse.academy';
     if (this.transporter) {
       await this.transporter.sendMail({ from, to, subject, text });
@@ -45,21 +46,22 @@ export class EmailService {
   async sendPasswordReset(
     to: string,
     resetToken: string,
-    baseUrl: string,
+    baseUrl?: string,
   ): Promise<void> {
     const from =
-      this.configService.get<string>('emailFrom') ??
+      this.configService.get<string>('email.from') ??
       'noreply@chainverse.academy';
-    const resetLink = `${baseUrl}/reset-password?token=${resetToken}`;
+    const resetBaseUrl =
+      baseUrl ?? this.configService.get<string>('baseUrl') ??
+      'http://localhost:3000';
+    const resetLink = `${resetBaseUrl}/reset-password?token=${resetToken}`;
 
     const mailOptions = {
       from,
       to,
-      subject: 'Password Reset Request',
-      text: `You requested a password reset. Click the link to reset your password: ${resetLink}\n\nIf you did not request this, please ignore this email.`,
-      html: `<p>You requested a password reset.</p>
-<p><a href="${resetLink}">Click here to reset your password</a></p>
-<p>If you did not request this, please ignore this email.</p>`,
+      subject: 'Reset your ChainVerse password',
+      text: `Click here to reset your password: ${resetLink}\n\nExpires in 15 minutes.`,
+      html: `Click <a href="${resetLink}">here</a> to reset your password. Expires in 15 minutes.`,
     };
 
     if (this.transporter) {

--- a/src/organization-member/organization-member.controller.ts
+++ b/src/organization-member/organization-member.controller.ts
@@ -18,7 +18,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller('organization-members')
+@Controller(['organization-members', 'organization-member'])
 export class OrganizationMemberController {
   constructor(private readonly service: OrganizationMemberService) {}
 

--- a/src/organization/organization.controller.ts
+++ b/src/organization/organization.controller.ts
@@ -18,7 +18,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller('organizations')
+@Controller(['organizations', 'organization'])
 export class OrganizationController {
   constructor(private readonly service: OrganizationService) {}
 

--- a/src/session/session.controller.ts
+++ b/src/session/session.controller.ts
@@ -18,7 +18,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller('sessions')
+@Controller(['sessions', 'session'])
 @UseGuards(JwtAuthGuard)
 export class SessionController {
   constructor(private readonly service: SessionService) {}

--- a/test/module-registration.e2e-spec.ts
+++ b/test/module-registration.e2e-spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from './../src/app.module';
+import { makeAdminToken, makeStudentToken } from './helpers/jwt.helper';
+
+describe('Module registration smoke tests', () => {
+  let app: INestApplication;
+  let server: any;
+  const adminToken = makeAdminToken();
+  const studentToken = makeStudentToken();
+  const studentId = 'seed-student-id';
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    server = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should create a session via POST /api/session with auth', async () => {
+    const payload = {
+      token: 'test-session-token',
+      ipAddress: '127.0.0.1',
+      userAgent: 'supertest',
+    };
+
+    const res = await request(server)
+      .post('/api/session')
+      .set('Authorization', `Bearer ${studentToken}`)
+      .send(payload)
+      .expect(201);
+
+    expect(res.body).toMatchObject({
+      token: payload.token,
+      ipAddress: payload.ipAddress,
+      userAgent: payload.userAgent,
+      userId: studentId,
+    });
+  });
+
+  it('should list organizations via GET /api/organization', async () => {
+    const res = await request(server).get('/api/organization').expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('should list organization members for a user via GET /api/organization-member/user/:userId', async () => {
+    const res = await request(server)
+      .get(`/api/organization-member/user/${studentId}`)
+      .set('Authorization', `Bearer ${studentToken}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('should cache FAQ list and invalidate it after update', async () => {
+    const createRes = await request(server)
+      .post('/api/faq')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Smoke Test FAQ',
+        description: 'Verify cache invalidation behavior',
+      })
+      .expect(201);
+
+    const faqId = createRes.body._id ?? createRes.body.id;
+    expect(faqId).toBeDefined();
+
+    const first = await request(server).get('/api/faq').expect(200);
+    expect(Array.isArray(first.body)).toBe(true);
+    expect(first.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Smoke Test FAQ',
+        }),
+      ]),
+    );
+
+    const second = await request(server).get('/api/faq').expect(200);
+    expect(second.body).toEqual(first.body);
+
+    await request(server)
+      .patch(`/api/faq/${faqId}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ title: 'Smoke Test FAQ Updated' })
+      .expect(200);
+
+    const updated = await request(server).get('/api/faq').expect(200);
+    expect(
+      updated.body.some(
+        (item: any) =>
+          (item._id === faqId || item.id === faqId) &&
+          item.title === 'Smoke Test FAQ Updated',
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #485 
closes #486
closes #488
closes #489

## PR description

- Verified `SessionModule` is imported into `AppModule`
- Verified `OrganizationModule` and `OrganizationMemberModule` are imported into `AppModule`
- Verified `FaqManagementModule` is registered and enabled global caching through `AppCacheModule`
- Added smoke tests for:
  - `POST /api/session`
  - `GET /api/organization`
  - `GET /api/organization-member/user/:userId`
  - FAQ caching and invalidation via `GET /api/faq`
- Updated email sending so password reset emails use real SMTP transport instead of falling back to console logging

