### PR TITLE
Stellar Proofpoint: verify-payment endpoint for enrollment handshake

### DIFF
--- a/src/stellar/stellar.controller.ts
+++ b/src/stellar/stellar.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { StellarService } from './stellar.service';
+
+interface VerifyPaymentDto {
+  transactionHash: string;
+  expectedAmount: string;
+  courseId: string;
+}
+
+@Controller('api/v1/stellar')
+export class StellarController {
+  constructor(private readonly stellarService: StellarService) {}
+
+  @Post('verify-payment')
+  async verifyPayment(@Body() body: VerifyPaymentDto) {
+    return this.stellarService.verifyPayment(body);
+  }
+}

--- a/src/stellar/stellar.module.ts
+++ b/src/stellar/stellar.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { StellarController } from './stellar.controller';
 import { StellarService } from './stellar.service';
 
 @Module({
+  controllers: [StellarController],
   providers: [StellarService],
   exports: [StellarService],
 })

--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -34,6 +34,21 @@ export class StellarService {
     }
   }
 
+  async verifyPayment(input: {
+    transactionHash: string;
+    expectedAmount: string;
+    courseId: string;
+  }): Promise<{ verified: boolean; transactionId: string; timestamp: string }> {
+    const { transactionHash } = input;
+    const tx = await this.server.transactions().transaction(transactionHash).call();
+
+    return {
+      verified: Boolean(tx?.successful),
+      transactionId: transactionHash,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
   getServer() {
     return this.server;
   }


### PR DESCRIPTION
Summary: adds the missing Stellar payment verification API endpoint needed by frontend before enrollment.

What changed:
- Added endpoint at /api/v1/stellar/verify-payment in StellarController.
- Added verifyPayment in StellarService to resolve transaction status by hash.
- Wired StellarController into StellarModule.
- Returns verified, transactionId, and timestamp response fields.

Closes #511