### PR TITLE
test: e2e auth/enrollment flows, pino redaction test, raise coverage to 40%

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
     ],
     "coverageThresholds": {
       "global": {
-        "statements": 20,
-        "branches": 15,
-        "functions": 20,
-        "lines": 20
+        "statements": 40,
+        "branches": 30,
+        "functions": 40,
+        "lines": 40
       }
     },
     "testEnvironment": "node"

--- a/src/logger/logger-redaction.spec.ts
+++ b/src/logger/logger-redaction.spec.ts
@@ -1,0 +1,87 @@
+import pino from 'pino';
+
+const REDACTED_PATHS = [
+  'req.headers.authorization',
+  'req.headers.cookie',
+  'req.body.password',
+  'req.body.newPassword',
+  'req.body.confirmPassword',
+  'req.body.currentPassword',
+  'req.body.token',
+  'req.body.refreshToken',
+];
+
+function makeLogger(chunks: string[]) {
+  return pino(
+    {
+      level: 'info',
+      redact: { paths: REDACTED_PATHS, censor: '[REDACTED]' },
+    },
+    {
+      write(chunk: string) {
+        chunks.push(chunk);
+      },
+    } as any,
+  );
+}
+
+describe('Pino log redaction', () => {
+  let chunks: string[];
+
+  beforeEach(() => {
+    chunks = [];
+  });
+
+  it('redacts req.headers.authorization and replaces with [REDACTED]', () => {
+    const logger = makeLogger(chunks);
+    logger.info({
+      req: {
+        headers: { authorization: 'Bearer super-secret-token', host: 'localhost' },
+        body: {},
+      },
+    });
+
+    const log = JSON.parse(chunks[0]!);
+    expect(log.req.headers.authorization).toBe('[REDACTED]');
+    expect(log.req.headers.host).toBe('localhost');
+  });
+
+  it('redacts req.body.password and replaces with [REDACTED]', () => {
+    const logger = makeLogger(chunks);
+    logger.info({
+      req: {
+        headers: {},
+        body: { email: 'user@example.com', password: 'my-secret-pass' },
+      },
+    });
+
+    const log = JSON.parse(chunks[0]!);
+    expect(log.req.body.password).toBe('[REDACTED]');
+    expect(log.req.body.email).toBe('user@example.com');
+  });
+
+  it('does not redact unrelated fields', () => {
+    const logger = makeLogger(chunks);
+    logger.info({ req: { headers: { host: 'api.chainverse.io' }, body: { name: 'Alice' } } });
+
+    const log = JSON.parse(chunks[0]!);
+    expect(log.req.headers.host).toBe('api.chainverse.io');
+    expect(log.req.body.name).toBe('Alice');
+  });
+
+  it('redacts req.headers.cookie', () => {
+    const logger = makeLogger(chunks);
+    logger.info({ req: { headers: { cookie: 'session=abc123' }, body: {} } });
+
+    const log = JSON.parse(chunks[0]!);
+    expect(log.req.headers.cookie).toBe('[REDACTED]');
+  });
+
+  it('redacts req.body.refreshToken', () => {
+    const logger = makeLogger(chunks);
+    logger.info({ req: { headers: {}, body: { refreshToken: 'tok.abc.xyz' } } });
+
+    const log = JSON.parse(chunks[0]!);
+    expect(log.req.body.refreshToken).toBe('[REDACTED]');
+  });
+});

--- a/test/enrollment.e2e-spec.ts
+++ b/test/enrollment.e2e-spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import request from 'supertest';
+import { Server } from 'http';
+import { AppModule } from '../src/app.module';
+import { Student } from '../src/student-auth/schemas/student.schema';
+import { Course } from '../src/admin-course/schemas/course.schema';
+import { Enrollment } from '../src/student-enrollment/schemas/enrollment.schema';
+import { CartItem } from '../src/student-cart/schemas/cart-item.schema';
+
+/**
+ * E2E test for the course enrollment flow:
+ *   browse courses → add to cart → enroll free → access content
+ */
+describe('Enrollment – E2E flow (#538)', () => {
+  let app: INestApplication;
+  let server: Server;
+  let studentModel: Model<Student>;
+  let courseModel: Model<Course>;
+  let enrollmentModel: Model<Enrollment>;
+  let cartItemModel: Model<CartItem>;
+
+  const EMAIL = `e2e.enroll.${Date.now()}@example.com`;
+  const PASSWORD = 'EnrollPass1!';
+  let accessToken: string;
+  let courseId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+    server = app.getHttpServer() as Server;
+
+    studentModel = moduleFixture.get<Model<Student>>(getModelToken(Student.name));
+    courseModel = moduleFixture.get<Model<Course>>(getModelToken(Course.name));
+    enrollmentModel = moduleFixture.get<Model<Enrollment>>(getModelToken(Enrollment.name));
+    cartItemModel = moduleFixture.get<Model<CartItem>>(getModelToken(CartItem.name));
+
+    // Seed a published free course directly in DB
+    const course = await courseModel.create({
+      title: 'E2E Free Course',
+      description: 'Course for e2e enrollment testing',
+      category: 'test',
+      price: 0,
+      tutorId: 'e2e-tutor-id',
+      tutorEmail: 'tutor@e2e.test',
+      tutorName: 'E2E Tutor',
+      status: 'published',
+    });
+    courseId = (course as any)._id.toString();
+
+    // Register + verify + login
+    await request(server)
+      .post('/student/register')
+      .send({ firstName: 'Enroll', lastName: 'User', email: EMAIL, password: PASSWORD });
+
+    const student = await studentModel.findOne({ email: EMAIL }).exec();
+    if (student?.verificationToken) {
+      await request(server)
+        .post('/student/verify-email')
+        .send({ token: student.verificationToken });
+    }
+
+    const loginRes = await request(server)
+      .post('/student/login')
+      .send({ email: EMAIL, password: PASSWORD });
+    accessToken = loginRes.body.accessToken as string;
+  });
+
+  afterAll(async () => {
+    const student = await studentModel.findOne({ email: EMAIL }).exec();
+    if (student) {
+      await enrollmentModel.deleteMany({ studentId: student.id }).exec();
+      await cartItemModel.deleteMany({ studentId: student.id }).exec();
+      await studentModel.deleteOne({ email: EMAIL }).exec();
+    }
+    await courseModel.deleteOne({ title: 'E2E Free Course' }).exec();
+    await app.close();
+  });
+
+  // 1. Browse courses — list with pagination
+  it('GET /courses → 200, list with pagination', async () => {
+    const res = await request(server).get('/courses').expect(200);
+    expect(res.body).toHaveProperty('courses');
+    expect(res.body).toHaveProperty('pagination');
+    expect(Array.isArray(res.body.courses)).toBe(true);
+  });
+
+  // 2. Add to cart
+  it('POST /student/cart → 200/201, item added', async () => {
+    const res = await request(server)
+      .post('/student/cart')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ courseId })
+      .expect((r) => {
+        if (r.status !== 200 && r.status !== 201) {
+          throw new Error(`Expected 200/201, got ${r.status}: ${JSON.stringify(r.body)}`);
+        }
+      });
+
+    expect(res.body).toBeDefined();
+  });
+
+  // 3. Enroll in free course
+  it('POST /student/enrollment/free/:courseId → 201', async () => {
+    const res = await request(server)
+      .post(`/student/enrollment/free/${courseId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(201);
+
+    expect(res.body).toBeDefined();
+  });
+
+  // 4. Get my courses — includes the enrolled course
+  it('GET /student/enrollment/my-courses → 200, includes enrolled course', async () => {
+    const res = await request(server)
+      .get('/student/enrollment/my-courses')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    const enrolled = (res.body as any[]).some(
+      (item) => item.course?.id === courseId || item.enrollment?.courseId === courseId,
+    );
+    expect(enrolled).toBe(true);
+  });
+
+  // 5. Check is-enrolled
+  it(`GET /student/enrollment/is-enrolled/:courseId → { isEnrolled: true }`, async () => {
+    const res = await request(server)
+      .get(`/student/enrollment/is-enrolled/${courseId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.isEnrolled ?? res.body.enrolled).toBe(true);
+  });
+});

--- a/test/student-auth.e2e-spec.ts
+++ b/test/student-auth.e2e-spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import request from 'supertest';
+import { Server } from 'http';
+import { AppModule } from '../src/app.module';
+import { Student } from '../src/student-auth/schemas/student.schema';
+
+/**
+ * E2E test for the full student auth flow:
+ *   register → verify-email → login → access protected route →
+ *   refresh tokens → verify old refresh token is revoked
+ */
+describe('Student Auth – E2E flow (#537)', () => {
+  let app: INestApplication;
+  let server: Server;
+  let studentModel: Model<Student>;
+
+  const EMAIL = `e2e.auth.${Date.now()}@example.com`;
+  const PASSWORD = 'SecurePass1!';
+
+  let accessToken: string;
+  let refreshToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+    server = app.getHttpServer() as Server;
+    studentModel = moduleFixture.get<Model<Student>>(
+      getModelToken(Student.name),
+    );
+  });
+
+  afterAll(async () => {
+    await studentModel.deleteOne({ email: EMAIL }).exec();
+    await app.close();
+  });
+
+  // 1. Register
+  it('POST /student/register → 201, email queued', async () => {
+    const res = await request(server)
+      .post('/student/register')
+      .send({ firstName: 'E2E', lastName: 'User', email: EMAIL, password: PASSWORD })
+      .expect(201);
+
+    expect(res.body.message).toMatch(/verify your email/i);
+    expect(res.body.user?.email).toBe(EMAIL);
+    expect(res.body.user?.emailVerified).toBe(false);
+  });
+
+  // 2. Verify email using token stored in DB
+  it('POST /student/verify-email with token → 200', async () => {
+    const student = await studentModel.findOne({ email: EMAIL }).exec();
+    expect(student?.verificationToken).toBeTruthy();
+
+    await request(server)
+      .post('/student/verify-email')
+      .send({ token: student!.verificationToken })
+      .expect(200);
+
+    const verified = await studentModel.findOne({ email: EMAIL }).exec();
+    expect(verified?.emailVerified).toBe(true);
+  });
+
+  // 3. Login
+  it('POST /student/login → 200, returns accessToken + refreshToken', async () => {
+    const res = await request(server)
+      .post('/student/login')
+      .send({ email: EMAIL, password: PASSWORD })
+      .expect(200);
+
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+    accessToken = res.body.accessToken as string;
+    refreshToken = res.body.refreshToken as string;
+  });
+
+  // 4. Access protected route with valid accessToken
+  it('GET /student/enrollment/my-courses with accessToken → 200', () =>
+    request(server)
+      .get('/student/enrollment/my-courses')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200));
+
+  // 5. Refresh tokens
+  it('POST /student/refresh-token → 200, issues new token pair', async () => {
+    const res = await request(server)
+      .post('/student/refresh-token')
+      .send({ refreshToken })
+      .expect(200);
+
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+    // Store the new tokens for the next assertion
+    accessToken = res.body.accessToken as string;
+    const newRefreshToken: string = res.body.refreshToken as string;
+
+    // 6. Old refresh token must be rejected (token rotation)
+    await request(server)
+      .post('/student/refresh-token')
+      .send({ refreshToken })
+      .expect(401);
+
+    refreshToken = newRefreshToken;
+  });
+});


### PR DESCRIPTION
## Summary

- **#537** Add `test/student-auth.e2e-spec.ts`: register → verify-email (token read from DB) → login → access protected route → refresh token pair → assert old refresh token is revoked (401)
- **#538** Add `test/enrollment.e2e-spec.ts`: seed published free course in DB → register/login student → list courses (GET /courses) → add to cart → enroll free → GET my-courses → GET is-enrolled
- **#541** Add `src/logger/logger-redaction.spec.ts`: pino unit tests that capture log output and verify `req.headers.authorization` and `req.body.password` are replaced with `[REDACTED]`
- **#540** Raise Jest `coverageThresholds` to `statements: 40, branches: 30, functions: 40, lines: 40`

Closes #537
Closes #538
Closes #540
Closes #541