### PR TITLE
fix(api): course text index, unique email indexes, normalized routes, structured isEnrolled

### DIFF
--- a/src/admin-course/schemas/course.schema.ts
+++ b/src/admin-course/schemas/course.schema.ts
@@ -153,6 +153,6 @@ CourseSchema.index({ price: 1 });
 CourseSchema.index({ averageRating: 1 });
 CourseSchema.index({ totalEnrollments: 1 });
 CourseSchema.index({ tags: 1 });
-CourseSchema.index({ title: 'text', description: 'text' });
+CourseSchema.index({ title: 'text', description: 'text', tags: 'text' });
 
 applySoftDeleteSchema(CourseSchema);

--- a/src/student-auth/schemas/student.schema.ts
+++ b/src/student-auth/schemas/student.schema.ts
@@ -47,6 +47,5 @@ export class Student {
 
 export const StudentSchema = SchemaFactory.createForClass(Student);
 
-// Explicit indexes for query performance (unique constraint alone is not enough)
-StudentSchema.index({ email: 1 });
+StudentSchema.index({ email: 1 }, { unique: true });
 StudentSchema.index({ emailVerified: 1 });

--- a/src/student-auth/student-auth.controller.ts
+++ b/src/student-auth/student-auth.controller.ts
@@ -13,7 +13,7 @@ import { RefreshTokenDto } from './dto/refresh-token.dto';
 // Auth endpoints are more sensitive to brute-force: tighten to 10 req/min
 @Throttle({ default: { limit: 10, ttl: 60_000 } })
 @ApiTags('Student Auth')
-@Controller('student')
+@Controller('auth/student')
 export class StudentAuthController {
   constructor(private readonly studentAuthService: StudentAuthService) {}
 

--- a/src/student-enrollment/student-enrollment.controller.ts
+++ b/src/student-enrollment/student-enrollment.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Param, Req, UseGuards, BadRequestException } from '@nestjs/common';
+import { Controller, Post, Get, Param, Req, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
@@ -42,6 +42,6 @@ export class StudentEnrollmentController {
     @Param('courseId') courseId: string,
   ) {
     const enrolled = await this.service.isEnrolled(req.user.id, courseId);
-    return { isEnrolled: enrolled };
+    return { enrolled, courseId, studentId: req.user.id };
   }
 }

--- a/src/tutor/schemas/tutor.schema.ts
+++ b/src/tutor/schemas/tutor.schema.ts
@@ -86,6 +86,5 @@ export class Tutor {
 
 export const TutorSchema = SchemaFactory.createForClass(Tutor);
 
-// Index for efficient lookups
-TutorSchema.index({ email: 1 });
+TutorSchema.index({ email: 1 }, { unique: true });
 TutorSchema.index({ accountStatus: 1 });


### PR DESCRIPTION
## Summary

- **#529** Extend course text index to include `tags` field — `{ title: 'text', description: 'text', tags: 'text' }`. The service already uses `$text`, so tag-based searches now hit the index instead of doing a collection scan
- **#530** Make the `email` field index explicitly `{ unique: true }` on both `StudentSchema` and `TutorSchema`, matching the `@Prop({ unique: true })` constraint and removing the redundant non-unique index
- **#531** Change `StudentAuthController` prefix from `'student'` to `'auth/student'`, making all routes `POST /api/v1/auth/student/register`, `POST /api/v1/auth/student/login`, etc.
- **#532** Return structured JSON from `GET /student/enrollment/is-enrolled/:courseId`: `{ enrolled, courseId, studentId }` instead of the bare `{ isEnrolled }` boolean

Closes #529
Closes #530
Closes #531
Closes #532