### PR TITLE
feat(api): EnrollmentGuard for course content access + confirm N+1 fixes

### DIFF
--- a/src/common/guards/enrollment.guard.ts
+++ b/src/common/guards/enrollment.guard.ts
@@ -1,0 +1,43 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { StudentEnrollmentService } from '../../student-enrollment/student-enrollment.service';
+
+/**
+ * Rejects requests from students who are not enrolled in the requested course.
+ * Expects:
+ *   - req.user.id  — set by JwtAuthGuard
+ *   - req.params.courseId — the course being accessed
+ *
+ * Apply after JwtAuthGuard so req.user is always populated.
+ */
+@Injectable()
+export class EnrollmentGuard implements CanActivate {
+  constructor(
+    private readonly enrollmentService: StudentEnrollmentService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<{
+      user: { id: string };
+      params: { courseId?: string };
+    }>();
+
+    const courseId = req.params.courseId;
+    if (!courseId) {
+      throw new ForbiddenException('courseId route parameter is required');
+    }
+
+    const enrolled = await this.enrollmentService.isEnrolled(
+      req.user.id,
+      courseId,
+    );
+    if (!enrolled) {
+      throw new ForbiddenException('Not enrolled in this course');
+    }
+    return true;
+  }
+}

--- a/src/student-enrollment/student-enrollment.controller.ts
+++ b/src/student-enrollment/student-enrollment.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Post, Get, Param, Req, UseGuards, BadRequestException } from '@nestjs/common';
+import { Controller, Post, Get, Param, Req, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
+import { EnrollmentGuard } from '../common/guards/enrollment.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 import { StudentEnrollmentService } from './student-enrollment.service';
@@ -43,5 +44,20 @@ export class StudentEnrollmentController {
   ) {
     const enrolled = await this.service.isEnrolled(req.user.id, courseId);
     return { isEnrolled: enrolled };
+  }
+
+  @ApiOperation({
+    summary: 'Access course content — requires active enrollment',
+  })
+  @Get('content/:courseId')
+  @UseGuards(EnrollmentGuard)
+  getCourseContent(
+    @Req() req: { user: { id: string } },
+    @Param('courseId') courseId: string,
+  ) {
+    return this.service.getMyCourses(req.user.id).then((courses) => {
+      const entry = courses.find((c) => c.enrollment.courseId === courseId);
+      return entry ?? { courseId, message: 'Content access granted' };
+    });
   }
 }


### PR DESCRIPTION
## Summary

- **#528** Create `EnrollmentGuard` (`src/common/guards/enrollment.guard.ts`): reads `req.params.courseId`, calls `StudentEnrollmentService.isEnrolled`, throws `ForbiddenException('Not enrolled in this course')` if check fails. Wire it on `GET /student/enrollment/content/:courseId` — unenrolled students receive 403
- **#521** `checkoutCart` already throws `NotImplementedException` for paid courses (confirmed present on main)
- **#522** `getCart` already uses a single `$in` query + Map instead of per-item `findById` calls (confirmed present on main)
- **#523** `getMyCourses` already uses a single `$in` query + Map instead of per-enrollment `findById` calls (confirmed present on main)

Closes #521
Closes #522
Closes #523
Closes #528