### PR TITLE
test: per-suite MongoMemoryServer setup for e2e tests

### DIFF
--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -7,6 +7,7 @@
     "^.+\\.(t|j)s$": ["ts-jest", { "tsconfig": "<rootDir>/tsconfig.json" }]
   },
   "setupFiles": ["<rootDir>/setup-env.ts"],
+  "setupFilesAfterEnv": ["<rootDir>/setup.ts"],
   "globalSetup": "<rootDir>/mongo-setup.ts",
   "globalTeardown": "<rootDir>/mongo-teardown.ts"
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,30 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+/**
+ * Per-suite in-memory MongoDB setup.
+ *
+ * Jest runs this file as part of `setupFilesAfterEnv`, which means
+ * beforeAll/afterAll execute within each test file's worker process,
+ * giving every e2e suite its own isolated database instance.
+ *
+ * When the CI `globalSetup` (mongo-setup.ts) has already started a shared
+ * instance and written the URI to a tmp-file, `setup-env.ts` picks it up
+ * via `setupFiles` before this file runs. In that case `process.env.MONGO_URI`
+ * is already set and we skip starting a second server.
+ */
+
+let mongo: MongoMemoryServer | undefined;
+
+beforeAll(async () => {
+  if (!process.env.MONGO_URI) {
+    mongo = await MongoMemoryServer.create();
+    process.env.MONGO_URI = mongo.getUri();
+  }
+}, 60_000);
+
+afterAll(async () => {
+  if (mongo) {
+    await mongo.stop();
+    mongo = undefined;
+  }
+});


### PR DESCRIPTION
## Summary

Closes #539

### What changed

**`test/setup.ts`** (new file)
Provides `beforeAll`/`afterAll` hooks that start and stop a `MongoMemoryServer` for each e2e test suite. The guard `if (!process.env.MONGO_URI)` means it only starts a fresh instance when the shared CI `globalSetup` (mongo-setup.ts) hasn't already provided one — no duplicate processes in CI, but full isolation when running a single suite locally.

**`test/jest-e2e.json`**
Adds `"setupFilesAfterEnv": ["<rootDir>/setup.ts"]`. This is the correct Jest lifecycle hook for files that use `beforeAll`/`afterAll` — unlike `globalSetup` (which runs in a separate Node process without the Jest test framework), `setupFilesAfterEnv` runs inside each worker process where the Jest globals are available.

### Execution order per test file
1. `globalSetup` → `mongo-setup.ts` starts shared MongoMemoryServer, writes URI to tmpfile
2. `setupFiles` → `setup-env.ts` reads URI from tmpfile, sets `process.env.MONGO_URI`
3. `setupFilesAfterEnv` → `setup.ts` `beforeAll`: MONGO_URI already set → skips starting a second server
4. Test suite runs against the shared in-memory MongoDB
5. `setupFilesAfterEnv` → `setup.ts` `afterAll`: nothing to stop
6. `globalTeardown` → `mongo-teardown.ts` stops the shared server

When running without CI global setup (e.g. `npx jest --testPathPattern=foo.e2e`), `setup.ts` starts its own server, ensuring every e2e run always has a real MongoDB.

Closes #539