### PR TITLE
ci: verify Docker image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,12 @@ jobs:
   docker-build:
     name: Docker build
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [unit, e2e]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build container image
-        run: docker build -t chainverse-backend-ci .
+      - name: Build Docker image
+        run: docker build -t chainverse-backend:ci .
 
   # -----------------------------------------------------------------------
   # 3. Unit tests + coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,33 @@
+# --- Builder Stage ---
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
 
 # --- Runner Stage ---
 FROM node:20-alpine AS runner
+
 WORKDIR /app
+
 ENV NODE_ENV=production
-# Create non-root user and group
+
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --omit=dev
+
 COPY --from=builder /app/dist ./dist
+
 USER appuser
+
 EXPOSE 3000
+
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD wget -qO- http://localhost:3000/health || exit 1
+
 CMD ["node", "dist/main"]


### PR DESCRIPTION
## Summary

- Updated the CI Docker build job to run after the test jobs complete
- Changed the Docker build command to use the requested image tag: `chainverse-backend:ci`
- Added the missing Docker `builder` stage so `COPY --from=builder` references a valid build stage

## Validation

- `npm ci` ✅
- `docker build -t chainverse-backend:ci .` ⚠️ reaches `RUN npm run build`, then fails due to existing TypeScript build errors
- `npm run build` ⚠️ fails locally with the same existing TypeScript errors outside Docker

## Notes

The original Docker failure was caused by the Dockerfile referencing `COPY --from=builder` without defining a `builder` stage. This caused Docker to try resolving `builder:latest` as an external image.

This PR fixes that Dockerfile structure issue and updates CI to verify the Docker image build after tests pass.

The remaining Docker build failure is caused by existing TypeScript compilation errors in the application code, which are reproducible with `npm run build` outside Docker and are intentionally left out of scope for this CI/Docker-focused issue.

Closes #684