### PR TITLE
ci: update npm install command to use --only=production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV NODE_ENV=production
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --only=production
 
 COPY --from=builder /app/dist ./dist
 


### PR DESCRIPTION
## What does this PR do?

Production image now installs only production deps (dev tooling removed); multi-stage build remains intact.

## Related issue(s)

Closes #592 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How has this been tested?

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing

## Checklist

- [ ] Tests pass locally
- [ ] Swagger docs updated
- [ ] `.env.example` updated (if new env vars added)
