### PR TITLE
fix: register AppLoggerModule to activate pino redaction (#638) + verify #629, #644, #681

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AppLoggerModule } from './logger/logger.module';
 import { JwtModule } from '@nestjs/jwt';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
@@ -153,6 +154,7 @@ import { TutorReportsAnalyticsModule } from './tutor-reports-analytics/tutor-rep
       }),
       inject: [ConfigService],
     }),
+    AppLoggerModule,
     WorkerModule,
     MetricsModule,
     TracingModule,


### PR DESCRIPTION
## Summary

This PR addresses all four open issues assigned to me.

### #638 — Pino log redaction not active (code fix)
`AppLoggerModule` (which configures `nestjs-pino` with field redaction) was never imported into `AppModule`. Without this registration, NestJS DI cannot provide the `Logger` instance that `main.ts` requests via `app.useLogger(app.get(Logger))`, meaning sensitive fields (`Authorization` headers, passwords, tokens) were **not** being redacted from logs.

**Fix:** Added `AppLoggerModule` to `AppModule` imports in `src/app.module.ts`.

### #629 — console.log of raw reset tokens (already resolved)
Both `tutor.service.ts` and `student-auth.service.ts` pass the token directly to `emailService.sendPasswordReset()` with no `console.log` of the raw token. No code change needed.

### #644 — Stellar env vars missing from .env.example (already resolved)
`.env.example` already contains `STELLAR_HORIZON_URL`, `STELLAR_NETWORK_PASSPHRASE`, `STELLAR_RPC_URL`, `STELLAR_NETWORK`, and all five `CONTRACT_*` addresses. No code change needed.

### #681 — CI workflow missing (already resolved)
`.github/workflows/ci.yml` already exists with lint, build, unit test, e2e, and Docker build jobs. No code change needed.

## Changes
- `src/app.module.ts` — import and register `AppLoggerModule`

Closes #629
Closes #638
Closes #644
Closes #681