### PR TITLE
fix: resolve Stellar Wave issues #642 #646 #648 #649

### DIFF
--- a/src/course-certification-nft-achievements/course-certification-nft-achievements.service.ts
+++ b/src/course-certification-nft-achievements/course-certification-nft-achievements.service.ts
@@ -1,5 +1,14 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+} from '@stellar/stellar-sdk';
+import { Server as SorobanServer, Api as SorobanApi } from '@stellar/stellar-sdk/rpc';
+import { StellarService } from '../stellar/stellar.service';
 import { CreateCourseCertificationNftAchievementsDto } from './dto/create-course-certification-nft-achievements.dto';
 import { UpdateCourseCertificationNftAchievementsDto } from './dto/update-course-certification-nft-achievements.dto';
 import { DomainEvents } from '../events/event-names';
@@ -7,11 +16,16 @@ import { CertificateIssuedPayload } from '../events/payloads/certificate-issued.
 
 @Injectable()
 export class CourseCertificationNftAchievementsService {
+  private readonly logger = new Logger(CourseCertificationNftAchievementsService.name);
   private readonly items: Array<
-    { id: string } & CreateCourseCertificationNftAchievementsDto
+    { id: string; transactionHash?: string } & CreateCourseCertificationNftAchievementsDto
   > = [];
 
-  constructor(private readonly eventEmitter: EventEmitter2) {}
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+    private readonly stellarService: StellarService,
+    private readonly configService: ConfigService,
+  ) {}
 
   findAll() {
     return this.items;
@@ -27,9 +41,23 @@ export class CourseCertificationNftAchievementsService {
     return item;
   }
 
-  create(payload: CreateCourseCertificationNftAchievementsDto) {
-    const created = { id: crypto.randomUUID(), ...payload };
+  async create(payload: CreateCourseCertificationNftAchievementsDto) {
+    const created: { id: string; transactionHash?: string } & CreateCourseCertificationNftAchievementsDto = {
+      id: crypto.randomUUID(),
+      ...payload,
+    };
     this.items.push(created);
+
+    // Issue certificate on-chain via the Soroban certificates contract
+    try {
+      created.transactionHash = await this.issueCertificateOnChain(
+        created.id,
+        payload.studentId,
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`On-chain certificate issuance failed for ${created.id}: ${msg}`);
+    }
 
     this.eventEmitter.emit(
       DomainEvents.CERTIFICATE_ISSUED,
@@ -58,5 +86,71 @@ export class CourseCertificationNftAchievementsService {
     }
     this.items.splice(index, 1);
     return { id, deleted: true };
+  }
+
+  private async issueCertificateOnChain(
+    certificateId: string,
+    studentId: string,
+  ): Promise<string> {
+    const contractAddress = this.configService.get<string>('CONTRACT_CERTIFICATES');
+    const secretKey = this.configService.get<string>('STELLAR_BACKEND_SECRET');
+    const rpcUrl =
+      this.configService.get<string>('STELLAR_RPC_URL') ??
+      'https://soroban-testnet.stellar.org';
+    const networkPassphrase =
+      this.configService.get<string>('STELLAR_NETWORK_PASSPHRASE') ??
+      'Test SDF Network ; September 2015';
+
+    if (!contractAddress || !secretKey) {
+      throw new Error('CONTRACT_CERTIFICATES or STELLAR_BACKEND_SECRET is not configured');
+    }
+
+    const keypair = Keypair.fromSecret(secretKey);
+    const rpc = new SorobanServer(rpcUrl);
+    const account = await rpc.getAccount(keypair.publicKey());
+
+    const contract = new Contract(contractAddress);
+    const operation = contract.call(
+      'mint',
+      nativeToScVal(certificateId, { type: 'string' }),
+      nativeToScVal(studentId, { type: 'string' }),
+    );
+
+    const tx = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase,
+    })
+      .addOperation(operation)
+      .setTimeout(30)
+      .build();
+
+    const preparedTx = await rpc.prepareTransaction(tx);
+    preparedTx.sign(keypair);
+
+    const result = await rpc.sendTransaction(preparedTx);
+
+    if (result.status === 'ERROR') {
+      throw new Error(`Soroban tx error: ${JSON.stringify(result.errorResult)}`);
+    }
+
+    // Poll for confirmation (up to ~20 seconds)
+    const txHash = result.hash;
+    let getResult = await rpc.getTransaction(txHash);
+    let attempts = 0;
+
+    while (
+      getResult.status === SorobanApi.GetTransactionStatus.NOT_FOUND &&
+      attempts < 10
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      getResult = await rpc.getTransaction(txHash);
+      attempts++;
+    }
+
+    if (getResult.status !== SorobanApi.GetTransactionStatus.SUCCESS) {
+      throw new Error(`Soroban tx did not confirm: ${getResult.status}`);
+    }
+
+    return txHash;
   }
 }

--- a/src/stellar/dto/verify-payment.dto.ts
+++ b/src/stellar/dto/verify-payment.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class VerifyPaymentDto {
+  @ApiProperty({ description: 'Stellar transaction hash to verify' })
+  @IsString()
+  @IsNotEmpty()
+  transactionHash: string;
+
+  @ApiProperty({ description: 'Expected payment amount' })
+  @IsString()
+  @IsNotEmpty()
+  expectedAmount: string;
+
+  @ApiProperty({ description: 'Course ID for the payment' })
+  @IsString()
+  @IsNotEmpty()
+  courseId: string;
+}

--- a/src/stellar/stellar.controller.ts
+++ b/src/stellar/stellar.controller.ts
@@ -1,12 +1,7 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { StellarService } from './stellar.service';
-
-interface VerifyPaymentDto {
-  transactionHash: string;
-  expectedAmount: string;
-  courseId: string;
-}
+import { VerifyPaymentDto } from './dto/verify-payment.dto';
 
 @ApiTags('Stellar')
 @Controller('api/v1/stellar')

--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -1,17 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Horizon, StrKey } from '@stellar/stellar-sdk';
-
-@Injectable()
-export class StellarService {
-  private readonly server: Horizon.Server;
-  private server: Horizon.Server;
-
-  constructor(private readonly config: ConfigService) {
-    const url =
-      this.config.get<string>('STELLAR_HORIZON_URL') ??
-      'https://horizon-testnet.stellar.org';
-    this.server = new Horizon.Server(url);
 import { Horizon, Keypair, StrKey } from '@stellar/stellar-sdk';
 
 @Injectable()
@@ -33,8 +21,6 @@ export class StellarService {
     return StrKey.isValidEd25519PublicKey(key);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async submitTransaction(transaction: any) {
   async submitTransaction(transaction: Parameters<Horizon.Server['submitTransaction']>[0]) {
     return this.server.submitTransaction(transaction);
   }


### PR DESCRIPTION
## Summary

Resolves all 4 Stellar Wave issues assigned to me.

### #648 — Create StellarModule and register in AppModule
No changes needed. `StellarModule` already has `@Global()` decorator and is imported in `AppModule`.

### #649 — Add endpoint to verify Stellar transaction hash
- Extracted inline `VerifyPaymentDto` interface into a proper DTO class with `class-validator` decorators (`@IsString()`, `@IsNotEmpty()`, `@ApiProperty()`)
- Fixed corrupted `stellar.service.ts` which had two versions of the class merged together (duplicate `server` field + duplicate method signatures)

### #646 — Implement on-chain certificate issuance
- Added `issueCertificateOnChain()` private method in `CourseCertificationNftAchievementsService`
- Loads `CONTRACT_CERTIFICATES` contract address and `STELLAR_BACKEND_SECRET` from config
- Builds a Soroban transaction calling the `mint` function with `certificateId` and `studentId`
- Signs with backend Stellar keypair, submits via `SorobanRpc.Server`, and polls until confirmed
- Stores the confirmed transaction hash on the certificate record
- Failure is logged as a warning but does not block certificate creation (graceful degradation)
- `StellarService` and `ConfigService` injected (no module changes needed since `StellarModule` is `@Global()`)

### #642 — Prevent email enumeration in forgetPassword
No changes needed. The `forgetPassword` method in `StudentAuthService` already returns the same message (`'If the email exists, a reset link has been sent'`) regardless of whether the email exists in the database.

## Files Changed
- `src/stellar/stellar.service.ts` — fixed duplicate declarations
- `src/stellar/stellar.controller.ts` — use proper DTO class
- `src/stellar/dto/verify-payment.dto.ts` — new DTO with validation
- `src/course-certification-nft-achievements/course-certification-nft-achievements.service.ts` — on-chain issuance

Closes #642
Closes #646
Closes #648
Closes #649