### PR TITLE
fix: resolve stellar wave issues (#639, #650, #651, #652)

### DIFF
--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -19,6 +19,12 @@ export const envValidationSchema = Joi.object({
   JWT_REFRESH_SECRET: Joi.string().min(32).required(),
 
   ALLOWED_ORIGINS: Joi.string().default('http://localhost:3000'),
+
+  // Stellar — secret key required in production so reward/certificate signing works
+  STELLAR_BACKEND_SECRET: Joi.string().when('NODE_ENV', {
+    is: 'production',
+    then: Joi.required(),
+  }),
 });
 
 /**

--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -1,17 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Horizon, StrKey } from '@stellar/stellar-sdk';
-
-@Injectable()
-export class StellarService {
-  private readonly server: Horizon.Server;
-  private server: Horizon.Server;
-
-  constructor(private readonly config: ConfigService) {
-    const url =
-      this.config.get<string>('STELLAR_HORIZON_URL') ??
-      'https://horizon-testnet.stellar.org';
-    this.server = new Horizon.Server(url);
 import { Horizon, Keypair, StrKey } from '@stellar/stellar-sdk';
 
 @Injectable()
@@ -33,9 +21,9 @@ export class StellarService {
     return StrKey.isValidEd25519PublicKey(key);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async submitTransaction(transaction: any) {
-  async submitTransaction(transaction: Parameters<Horizon.Server['submitTransaction']>[0]) {
+  async submitTransaction(
+    transaction: Parameters<Horizon.Server['submitTransaction']>[0],
+  ) {
     return this.server.submitTransaction(transaction);
   }
 
@@ -90,7 +78,11 @@ export class StellarService {
     };
   }
 
-  async createAccount(): Promise<{ publicKey: string; funded: boolean; message: string }> {
+  async createAccount(): Promise<{
+    publicKey: string;
+    funded: boolean;
+    message: string;
+  }> {
     const keypair = Keypair.random();
     const publicKey = keypair.publicKey();
 


### PR DESCRIPTION
## Summary

Resolves all four open issues assigned to me in the Stellar Wave milestone.

### Changes

**`src/stellar/stellar.service.ts`** — fix merge conflict artifacts
- Removed duplicate class declarations left over from an unresolved merge
- Removed duplicate `private server` property
- Removed duplicate `submitTransaction` signature (one was untyped `any`)
- Added `Keypair` to imports (already used in `createAccount`)

**`src/common/config/env.validation.ts`** — fix #651
- Added `STELLAR_BACKEND_SECRET` to the Joi validation schema; required in `production`, optional otherwise

### Already implemented (no code change needed)

- **#639** — `student-auth.service.ts` already throws `UnauthorizedException` when `!student.emailVerified` in `login()`
- **#650** — `GET /api/v1/stellar/balance/:publicKey` already exists in `stellar.controller.ts` / `stellar.service.ts`
- **#652** — `RewardListener` in `src/events/listeners/reward.listener.ts` already calls `claim_reward` on the reward contract when `CERTIFICATE_ISSUED` fires, and is registered in `events.module.ts`

Closes #639
Closes #650
Closes #651
Closes #652