### PR TITLE
Fix: Normalize routes, standardize error responses, enhance e2e tests

### DIFF
--- a/src/admin-moderator-account-settings/admin-moderator-account-settings.controller.ts
+++ b/src/admin-moderator-account-settings/admin-moderator-account-settings.controller.ts
@@ -10,7 +10,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller('admin-moderator/account-settings')
+@Controller('admin/moderator/account-settings')
 export class AdminModeratorAccountSettingsController {
   constructor(private readonly service: AdminModeratorAccountSettingsService) {}
 

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,4 +1,4 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logger, NotFoundException, BadRequestException, UnauthorizedException, ForbiddenException, ConflictException } from '@nestjs/common';
 import { Request, Response } from 'express';
 
 export interface ErrorResponse {
@@ -9,6 +9,21 @@ export interface ErrorResponse {
   timestamp: string;
   path: string;
   requestId?: string;
+}
+
+const EXCEPTION_ERROR_CODE_MAP: Array<{ type: new (...args: unknown[]) => HttpException; errorCode: string }> = [
+  { type: BadRequestException, errorCode: 'VAL_INVALID_INPUT' },
+  { type: UnauthorizedException, errorCode: 'AUTH_INVALID_TOKEN' },
+  { type: ForbiddenException, errorCode: 'AUTH_INSUFFICIENT_PERMISSIONS' },
+  { type: NotFoundException, errorCode: 'RES_NOT_FOUND' },
+  { type: ConflictException, errorCode: 'RES_ALREADY_EXISTS' },
+];
+
+function inferErrorCode(exception: HttpException): string | undefined {
+  for (const mapping of EXCEPTION_ERROR_CODE_MAP) {
+    if (exception instanceof mapping.type) return mapping.errorCode;
+  }
+  return undefined;
 }
 
 @Catch()
@@ -40,6 +55,10 @@ export class AllExceptionsFilter implements ExceptionFilter {
         message = (body.message as string | string[]) ?? exception.message;
         error = (body.error as string) ?? HttpStatus[statusCode] ?? 'Error';
         errorCode = body.errorCode as string | undefined;
+      }
+
+      if (!errorCode) {
+        errorCode = inferErrorCode(exception);
       }
     }
 

--- a/src/contact-message/contact-message.controller.ts
+++ b/src/contact-message/contact-message.controller.ts
@@ -10,7 +10,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller(['contact-messages', 'contact', 'v1/contact'])
+@Controller('contact-messages')
 export class ContactMessageController {
   constructor(private readonly service: ContactMessageService) {}
 

--- a/src/organization-member/organization-member.controller.ts
+++ b/src/organization-member/organization-member.controller.ts
@@ -10,7 +10,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller(['organization-members', 'organization-member'])
+@Controller('organization-members')
 export class OrganizationMemberController {
   constructor(private readonly service: OrganizationMemberService) {}
 

--- a/src/organization/organization.controller.ts
+++ b/src/organization/organization.controller.ts
@@ -10,7 +10,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller(['organizations', 'organization'])
+@Controller('organizations')
 export class OrganizationController {
   constructor(private readonly service: OrganizationService) {}
 

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { ReportsService } from './reports.service';
 
-@Controller(['reports', 'v1/reports'])
+@Controller('reports')
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 

--- a/src/session/session.controller.ts
+++ b/src/session/session.controller.ts
@@ -9,7 +9,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller(['sessions', 'session'])
+@Controller('sessions')
 @UseGuards(JwtAuthGuard)
 export class SessionController {
   constructor(private readonly service: SessionService) {}

--- a/src/stellar/stellar.controller.ts
+++ b/src/stellar/stellar.controller.ts
@@ -25,7 +25,7 @@ export class WalletPublicKeyDto {
 }
 
 @ApiTags('Stellar')
-@Controller('api/v1/stellar')
+@Controller('stellar')
 export class StellarController {
   constructor(private readonly stellarService: StellarService) {}
 

--- a/src/student-reports-analytics/student-reports-analytics.controller.ts
+++ b/src/student-reports-analytics/student-reports-analytics.controller.ts
@@ -10,7 +10,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller('student-reports-analytics')
+@Controller('student/reports-analytics')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles(Role.ADMIN, Role.MODERATOR)
 export class StudentReportsAnalyticsController {

--- a/src/student-saved-courses/student-saved-courses.controller.ts
+++ b/src/student-saved-courses/student-saved-courses.controller.ts
@@ -8,7 +8,7 @@ import { Roles } from '../common/decorators/roles.decorator';
 import { Role } from '../common/enums/role.enum';
 
 @ApiBearerAuth('access-token')
-@Controller('student/save')
+@Controller('student/saved-courses')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles(Role.STUDENT)
 export class StudentSavedCoursesController {

--- a/src/subscription-plan/subscription-plan.controller.ts
+++ b/src/subscription-plan/subscription-plan.controller.ts
@@ -10,7 +10,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
-@Controller(['subscription-plans', 'subscription-plan', 'v1/subscription-plan'])
+@Controller('subscription-plans')
 export class SubscriptionPlanController {
   constructor(private readonly service: SubscriptionPlanService) {}
 

--- a/test/enrollment.e2e-spec.ts
+++ b/test/enrollment.e2e-spec.ts
@@ -142,4 +142,37 @@ describe('Enrollment – E2E flow (#538)', () => {
 
     expect(res.body.isEnrolled ?? res.body.enrolled).toBe(true);
   });
+
+  // 6. Access course content
+  it('GET /student/enrollment/content/:courseId → 200, course content', async () => {
+    const res = await request(server)
+      .get(`/student/enrollment/content/${courseId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body).toBeDefined();
+  });
+
+  // 7. Access content without auth → 401
+  it('GET /student/enrollment/content/:courseId without token → 401', async () => {
+    await request(server)
+      .get(`/student/enrollment/content/${courseId}`)
+      .expect(401);
+  });
+
+  // 8. Enroll in non-existent course → 404
+  it('POST /student/enrollment/free/invalid-id → 404', async () => {
+    await request(server)
+      .post('/student/enrollment/free/000000000000000000000000')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
+  });
+
+  // 9. Re-enroll in same free course → 409
+  it('POST /student/enrollment/free/:courseId again → 409 conflict', async () => {
+    await request(server)
+      .post(`/student/enrollment/free/${courseId}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(409);
+  });
 });

--- a/test/student-auth.e2e-spec.ts
+++ b/test/student-auth.e2e-spec.ts
@@ -111,4 +111,19 @@ describe('Student Auth – E2E flow (#537)', () => {
 
     refreshToken = newRefreshToken;
   });
+
+  // 7. Logout
+  it('POST /auth/student/logout → 200, refresh token revoked', async () => {
+    await request(server)
+      .post('/auth/student/logout')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ refreshToken })
+      .expect(200);
+
+    // Old refresh token should now be invalid
+    await request(server)
+      .post('/student/refresh-token')
+      .send({ refreshToken })
+      .expect(401);
+  });
 });


### PR DESCRIPTION
This PR resolves multiple open issues in chainVerse-backend.

**Route Normalization (#669):**
- `student-reports-analytics` → `student/reports-analytics`
- `admin-moderator/account-settings` → `admin/moderator/account-settings`
- `student/save` → `student/saved-courses`
- `api/v1/stellar` → `stellar` (removed nested global prefix)
- Removed duplicate route registrations from 6 controllers (kept kebab plural form)

**Error Standardization (#663):**
- Enhanced `AllExceptionsFilter` with automatic error code inference for common NestJS exceptions (BadRequest → VAL_INVALID_INPUT, NotFound → RES_NOT_FOUND, Unauthorized → AUTH_INVALID_TOKEN, etc.)

**E2E Tests:**
- Added logout test to student auth flow (#675)
- Added content access, unauthorized access, 404, and re-enrollment conflict tests to enrollment flow (#676)

Closes #669, closes #663, closes #675, closes #676