### PR TITLE
fix(api): add textScore projection and relevance sorting for MongoDB text search (#667)

### DIFF
--- a/src/course-discovery/course-discovery.service.ts
+++ b/src/course-discovery/course-discovery.service.ts
@@ -57,7 +57,8 @@ export class CourseDiscoveryService {
     }
 
     // Build sort option
-    const sort: Record<string, number> = {};
+    const hasTextSearch = !!dto.query;
+    const sort: Record<string, unknown> = {};
     switch (dto.sortBy) {
       case 'price-asc':
         sort.price = 1;
@@ -75,14 +76,28 @@ export class CourseDiscoveryService {
         sort.createdAt = -1;
         break;
       default:
-        sort.createdAt = -1;
+        // When text search is active, sort by text relevance score;
+        // otherwise fall back to newest-first.
+        if (hasTextSearch) {
+          sort.score = { $meta: 'textScore' };
+        } else {
+          sort.createdAt = -1;
+        }
     }
 
     const limit = dto.limit || 20;
     const skip = dto.skip || 0;
 
+    // Include textScore metadata in the projection when using $text search
+    const projection = hasTextSearch ? { score: { $meta: 'textScore' } } : {};
+
     const [courses, total] = await Promise.all([
-      this.courseModel.find(query).sort(sort).limit(limit).skip(skip).exec(),
+      this.courseModel
+        .find(query, projection)
+        .sort(sort)
+        .limit(limit)
+        .skip(skip)
+        .exec(),
       this.courseModel.countDocuments(query).exec(),
     ]);
 


### PR DESCRIPTION
This PR enhances the course search by adding proper text relevance scoring and sorting when using MongoDB's \ search.

**Changes:**
- Added \hasTextSearch\ flag to detect when a text query is active
- Sorted results by \	extScore\ metadata when using \ search (relevance-based ranking)
- Included \	extScore\ in the projection for transparency
- When no text search is active, falls back to sorting by \createdAt\ (newest first)

Closes #667