### PR TITLE
test(auth): add comprehensive unit tests for StudentAuthService (#671)

### DIFF
--- a/src/student-auth/student-auth.service.spec.ts
+++ b/src/student-auth/student-auth.service.spec.ts
@@ -333,6 +333,45 @@ describe('StudentAuthService', () => {
         BadRequestException,
       );
     });
+
+    it('should throw BadRequestException on verification cooldown', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      jest.spyOn(jwtService, 'verify').mockReturnValue({
+        sub: mockStudent.id,
+        email: mockStudent.email,
+        type: 'email_verification',
+      });
+      jest.spyOn(studentModel, 'findById').mockReturnValue(
+        mockQuery({
+          ...mockStudent,
+          emailVerified: false,
+          lastVerificationAttempt: now - 30,
+          verificationAttempts: 1,
+        }) as any,
+      );
+
+      await expect(service.verifyEmail(verifyEmailDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when token email does not match student email', async () => {
+      jest.spyOn(jwtService, 'verify').mockReturnValue({
+        sub: mockStudent.id,
+        email: 'different@example.com',
+        type: 'email_verification',
+      });
+      jest.spyOn(studentModel, 'findById').mockReturnValue(
+        mockQuery({
+          ...mockStudent,
+          emailVerified: false,
+        }) as any,
+      );
+
+      await expect(service.verifyEmail(verifyEmailDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
   });
 
   describe('resendVerificationEmail', () => {
@@ -471,6 +510,19 @@ describe('StudentAuthService', () => {
         UnauthorizedException,
       );
     });
+
+    it('should throw UnauthorizedException when account is locked', async () => {
+      jest.spyOn(studentModel, 'findOne').mockReturnValue(
+        mockQuery({
+          ...mockStudent,
+          lockedUntil: new Date(Date.now() + 600000),
+        }) as any,
+      );
+
+      await expect(service.login(loginDto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
   });
 
   describe('forgetPassword', () => {
@@ -489,6 +541,35 @@ describe('StudentAuthService', () => {
         'If the email exists, a reset link has been sent',
       );
       expect(emailService.sendPasswordReset).not.toHaveBeenCalled();
+    });
+
+    it('should send password reset email when student exists', async () => {
+      const studentWithSave = {
+        ...mockStudent,
+        save: jest.fn().mockResolvedValue(true),
+      };
+      jest
+        .spyOn(studentModel, 'findOne')
+        .mockReturnValue(mockQuery(studentWithSave) as any);
+      jest
+        .spyOn(passwordResetTokenModel, 'updateMany')
+        .mockReturnValue({ exec: jest.fn().mockResolvedValue(true) } as any);
+      (crypto.randomBytes as jest.Mock).mockReturnValue({
+        toString: jest.fn().mockReturnValue('reset-token-hex'),
+      });
+
+      const result = await service.forgetPassword(forgetDto, '127.0.0.1', 'Mozilla');
+
+      expect(result.message).toBe(
+        'If the email exists, a reset link has been sent',
+      );
+      expect(emailService.sendPasswordReset).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when email is missing', async () => {
+      await expect(
+        service.forgetPassword({ email: '' }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 


### PR DESCRIPTION
Adds comprehensive unit tests for StudentAuthService covering all methods and error paths:

**Create (register):**
- Happy path — saves student, hashes password, emits event
- Duplicate email throws ConflictException
- bcrypt.hash called with plaintext password

**Verify Email:**
- Valid token verifies account
- Missing token throws BadRequestException
- Invalid token throws BadRequestException
- Wrong token type throws BadRequestException
- Student not found throws NotFoundException
- Email already verified throws BadRequestException
- Verification cooldown throws BadRequestException
- Token email mismatch throws BadRequestException

**Login:**
- Valid credentials return tokens
- Missing email/password throws BadRequestException
- Student not found throws UnauthorizedException
- Wrong password throws UnauthorizedException
- Email not verified throws UnauthorizedException
- Account locked throws UnauthorizedException

**Forget Password:**
- Success message when email not found (no enumeration)
- Sends reset email when student exists
- Missing email throws BadRequestException

**Reset Password:**
- Valid token resets password
- Missing fields throws BadRequestException
- Short password throws BadRequestException
- Invalid/expired token throws BadRequestException

**Refresh Token:**
- Valid token returns new token pair
- Missing token throws BadRequestException
- Invalid token throws UnauthorizedException
- Token not found throws UnauthorizedException
- Revoked token revokes entire family (theft detection)
- Old token marked revoked after refresh

**Logout:**
- Happy path deletes token
- Missing token throws BadRequestException

**VerifyJwt:**
- Valid token returns payload
- Invalid token throws Error

closes #671