### PR TITLE
fix(ci): env var validation, MongoDB service container, and e2e globalSetup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Validate required environment variables
         run: |
-          required_vars=("JWT_SECRET" "NODE_ENV")
+          required_vars=("JWT_SECRET" "NODE_ENV" "MONGO_URI")
           missing=0
           for var in "${required_vars[@]}"; do
             if [ -z "${!var}" ]; then


### PR DESCRIPTION
## Summary

Fixes all four open CI/test workflow issues in one pass.

### Changes

- **#690** — Add `MONGO_URI` to the `required_vars` list in the e2e job's "Validate required environment variables" step so the job fails fast if the variable is missing (was already set in `env:` but not validated).
- **#539** — `test/jest-e2e.json` already correctly references `mongo-setup.ts` as `globalSetup` and `mongo-teardown.ts` as `globalTeardown`, wiring `mongodb-memory-server` into e2e runs. No further change needed; confirming implementation is complete.
- **#544** — `mongo:7` service container with `mongosh` health checks is already present in the `e2e` CI job and `MONGO_URI` is set to `mongodb://localhost:27017/chainverse_test`. No further change needed; confirming implementation is complete.
- **#570** — Rate-limiting `@Throttle` decorators on student-auth and tutor auth endpoints were already merged via PR #570.

### What was tested

- Verified `ci.yml` diff: exactly one line changed (added `MONGO_URI` to array).
- Verified `jest-e2e.json` contains `globalSetup`, `globalTeardown`, `setupFiles`, and `setupFilesAfterEnv`.
- Verified `mongo-setup.ts` starts `MongoMemoryServer`, verifies the connection, and writes the URI to a tmp file for worker processes to consume.

Closes #690
Closes #539
Closes #544
Closes #570