### PR TITLE
fix(ci): add npm audit, npm cache, PR template, and branch protection docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,14 +11,14 @@ Repository admins must configure the following branch protection settings on `ma
 | Setting | Value |
 |---|---|
 | **Require status checks to pass before merging** | ✅ Enabled |
-| Required status checks | `CI / ci` |
+| Required status checks | `CI / Lint`, `CI / Build`, `CI / Unit tests`, `CI / E2E tests` |
 | **Require at least 1 approving review** | ✅ Enabled |
 | **Dismiss stale reviews when new commits are pushed** | ✅ Enabled |
 | **Require branches to be up to date before merging** | ✅ Enabled |
 
 ### Why each rule matters
 
-- **Status checks** — Prevents merging if lint, build, or tests are failing. The CI job name is `CI / ci` (defined in `.github/workflows/ci.yml`).
+- **Status checks** — Prevents merging if lint, build, or tests are failing. The required checks (`CI / Lint`, `CI / Build`, `CI / Unit tests`, `CI / E2E tests`) are defined in `.github/workflows/ci.yml`.
 - **Approving review** — Ensures at least one team member has reviewed the code before it lands on `main`.
 - **Dismiss stale reviews** — Forces re-review when the author pushes new changes after approval, preventing approval of old code.
 - **Up-to-date branches** — Requires the PR branch to be current with `main` before merging, avoiding integration surprises.


### PR DESCRIPTION
## What does this PR do?

Resolves four CI/workflow issues by verifying and correcting the CI workflow and supporting documentation.

### Changes

- **`.github/workflows/ci.yml`** — already contained:
  - `npm audit --audit-level=high` in the `lint` job (closes #686)
  - `cache: 'npm'` on every `actions/setup-node@v4` step (closes #689)
- **`.github/PULL_REQUEST_TEMPLATE.md`** — already present with all required sections (closes #687)
- **`CONTRIBUTING.md`** — fixed incorrect status check name: was `CI / ci` (no such job), now lists the actual job names `CI / Lint`, `CI / Build`, `CI / Unit tests`, `CI / E2E tests` (closes #688)

## Related issue(s)

Closes #686
Closes #687
Closes #688
Closes #689

## Type of change

- [x] Bug fix
- [x] Documentation

## How has this been tested?

- [x] Manual testing — verified YAML is valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Verified all four fixes are present in the workflow file

## Checklist

- [x] Tests pass locally
- [x] Swagger docs updated (N/A)
- [x] `.env.example` updated (N/A — no new env vars)