### PR TITLE
[Test] Write unit tests for StellarService — key validation, payment verification mock

### DIFF
--- a/src/stellar/stellar.service.spec.ts
+++ b/src/stellar/stellar.service.spec.ts
@@ -1,16 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { StellarService } from './stellar.service';
 import * as StellarSdk from '@stellar/stellar-sdk';
 
 jest.mock('@stellar/stellar-sdk', () => {
   const original = jest.requireActual('@stellar/stellar-sdk');
+  const mockServer = {
+    loadAccount: jest.fn(),
+    submitTransaction: jest.fn(),
+    transactions: jest.fn(),
+    operations: jest.fn(),
+  };
   return {
     ...original,
     Horizon: {
-      Server: jest.fn().mockImplementation(() => ({
-        loadAccount: jest.fn(),
-        submitTransaction: jest.fn(),
-      })),
+      Server: jest.fn().mockImplementation(() => mockServer),
     },
   };
 });
@@ -21,7 +25,15 @@ describe('StellarService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [StellarService],
+      providers: [
+        StellarService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue('https://horizon-testnet.stellar.org'),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<StellarService>(StellarService);
@@ -38,7 +50,7 @@ describe('StellarService', () => {
 
   describe('isValidPublicKey', () => {
     it('returns true for a valid G... Stellar public key', () => {
-      const validKey = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV4UHEIPZXB';
+      const validKey = 'GD2LMJIK7BVUHJRJP3XKOIUE5NTISZFLGW7AUH36B5QUERZ3L7ILQQDA';
       expect(service.isValidPublicKey(validKey)).toBe(true);
     });
 
@@ -58,14 +70,28 @@ describe('StellarService', () => {
         call: jest.fn(),
       };
       mockServer.transactions = jest.fn().mockReturnValue(txBuilder);
+      const opsBuilder = {
+        forTransaction: jest.fn().mockReturnThis(),
+        call: jest.fn().mockResolvedValue({
+          records: [
+            {
+              type: 'payment',
+              to: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
+              amount: '10',
+            },
+          ],
+        }),
+      };
+      mockServer.operations = jest.fn().mockReturnValue(opsBuilder);
     });
 
-    it('returns verified: true when Horizon reports the tx as successful', async () => {
+    it('returns { verified: true } when Horizon reports the tx as successful', async () => {
       mockServer.transactions().call.mockResolvedValue({ successful: true });
 
       const result = await service.verifyPayment({
         transactionHash: 'abc123hash',
         expectedAmount: '10',
+        expectedDestination: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
         courseId: 'course-1',
       });
 
@@ -74,99 +100,13 @@ describe('StellarService', () => {
       expect(typeof result.timestamp).toBe('string');
     });
 
-    it('returns verified: false when tx is not successful', async () => {
+    it('returns { verified: false } when tx is not successful', async () => {
       mockServer.transactions().call.mockResolvedValue({ successful: false });
 
       const result = await service.verifyPayment({
         transactionHash: 'bad-hash',
         expectedAmount: '10',
-        courseId: 'course-1',
-      });
-
-      expect(result.verified).toBe(false);
-    });
-
-    it('returns verified: false when Horizon returns null', async () => {
-      mockServer.transactions().call.mockResolvedValue(null);
-
-      const result = await service.verifyPayment({
-        transactionHash: 'missing',
-        expectedAmount: '5',
-        courseId: 'course-2',
-      });
-
-      expect(result.verified).toBe(false);
-    });
-  });
-
-  describe('getAccount', () => {
-    it('should return account details on success (happy path)', async () => {
-      const accountId = 'GA...';
-      const mockAccount = { id: accountId, sequence: '123' };
-      mockServer.loadAccount.mockResolvedValue(mockAccount);
-
-      const result = await service.getAccount(accountId);
-
-      expect(mockServer.loadAccount).toHaveBeenCalledWith(accountId);
-      expect(result).toEqual(mockAccount);
-    });
-
-    it('should throw error on failure (failure path)', async () => {
-      const accountId = 'GA...';
-      const error = new Error('Account not found');
-      mockServer.loadAccount.mockRejectedValue(error);
-
-      await expect(service.getAccount(accountId)).rejects.toThrow(
-        'Account not found',
-      );
-      expect(mockServer.loadAccount).toHaveBeenCalledWith(accountId);
-    });
-  });
-
-  describe('isValidPublicKey', () => {
-    it('returns true for a valid G... Stellar public key', () => {
-      const validKey = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV4UHEIPZXB';
-      expect(service.isValidPublicKey(validKey)).toBe(true);
-    });
-
-    it('returns false for a random string', () => {
-      expect(service.isValidPublicKey('not-a-stellar-key')).toBe(false);
-    });
-
-    it('returns false for an empty string', () => {
-      expect(service.isValidPublicKey('')).toBe(false);
-    });
-  });
-
-  describe('verifyPayment', () => {
-    beforeEach(() => {
-      const mockTxBuilder = {
-        transaction: jest.fn().mockReturnThis(),
-        call: jest.fn(),
-      };
-      mockServer.transactions = jest.fn().mockReturnValue(mockTxBuilder);
-    });
-
-    it('returns { verified: true } when Horizon reports the transaction as successful', async () => {
-      mockServer.transactions().call.mockResolvedValue({ successful: true });
-
-      const result = await service.verifyPayment({
-        transactionHash: 'abc123',
-        expectedAmount: '10',
-        courseId: 'course-1',
-      });
-
-      expect(result.verified).toBe(true);
-      expect(result.transactionId).toBe('abc123');
-      expect(typeof result.timestamp).toBe('string');
-    });
-
-    it('returns { verified: false } when transaction is not successful', async () => {
-      mockServer.transactions().call.mockResolvedValue({ successful: false });
-
-      const result = await service.verifyPayment({
-        transactionHash: 'abc123',
-        expectedAmount: '10',
+        expectedDestination: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
         courseId: 'course-1',
       });
 
@@ -177,12 +117,115 @@ describe('StellarService', () => {
       mockServer.transactions().call.mockResolvedValue(null);
 
       const result = await service.verifyPayment({
-        transactionHash: 'missing-hash',
-        expectedAmount: '10',
+        transactionHash: 'missing',
+        expectedAmount: '5',
+        expectedDestination: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
+        courseId: 'course-2',
+      });
+
+      expect(result.verified).toBe(false);
+    });
+
+    it('returns { verified: true } for matching amount and destination', async () => {
+      const opsBuilder = {
+        forTransaction: jest.fn().mockReturnThis(),
+        call: jest.fn().mockResolvedValue({
+          records: [
+            {
+              type: 'payment',
+              to: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
+              amount: '100',
+            },
+          ],
+        }),
+      };
+      mockServer.operations = jest.fn().mockReturnValue(opsBuilder);
+      mockServer.transactions().call.mockResolvedValue({ successful: true });
+
+      const result = await service.verifyPayment({
+        transactionHash: 'valid-hash',
+        expectedAmount: '100',
+        expectedDestination: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
+        courseId: 'course-1',
+      });
+
+      expect(result.verified).toBe(true);
+    });
+
+    it('returns { verified: false } for wrong amount', async () => {
+      const opsBuilder = {
+        forTransaction: jest.fn().mockReturnThis(),
+        call: jest.fn().mockResolvedValue({
+          records: [
+            {
+              type: 'payment',
+              to: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
+              amount: '50',
+            },
+          ],
+        }),
+      };
+      mockServer.operations = jest.fn().mockReturnValue(opsBuilder);
+      mockServer.transactions().call.mockResolvedValue({ successful: true });
+
+      const result = await service.verifyPayment({
+        transactionHash: 'wrong-amount-hash',
+        expectedAmount: '100',
+        expectedDestination: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
         courseId: 'course-1',
       });
 
       expect(result.verified).toBe(false);
+    });
+
+    it('returns { verified: false } for wrong destination', async () => {
+      const opsBuilder = {
+        forTransaction: jest.fn().mockReturnThis(),
+        call: jest.fn().mockResolvedValue({
+          records: [
+            {
+              type: 'payment',
+              to: 'GWRONGWRONGWRONGWRONGWRONGWRONGWRONGWRONG',
+              amount: '100',
+            },
+          ],
+        }),
+      };
+      mockServer.operations = jest.fn().mockReturnValue(opsBuilder);
+      mockServer.transactions().call.mockResolvedValue({ successful: true });
+
+      const result = await service.verifyPayment({
+        transactionHash: 'wrong-dest-hash',
+        expectedAmount: '100',
+        expectedDestination: 'GDESTDESTDESTDESTDESTDESTDESTDESTDESTDEST',
+        courseId: 'course-1',
+      });
+
+      expect(result.verified).toBe(false);
+    });
+  });
+
+  describe('getAccount', () => {
+    it('should return account details on success (happy path)', async () => {
+      const accountId = 'GD2LMJIK7BVUHJRJP3XKOIUE5NTISZFLGW7AUH36B5QUERZ3L7ILQQDA';
+      const mockAccount = { id: accountId, sequence: '123' };
+      mockServer.loadAccount.mockResolvedValue(mockAccount);
+
+      const result = await service.getAccount(accountId);
+
+      expect(mockServer.loadAccount).toHaveBeenCalledWith(accountId);
+      expect(result).toEqual(mockAccount);
+    });
+
+    it('should throw error on failure (failure path)', async () => {
+      const accountId = 'GD2LMJIK7BVUHJRJP3XKOIUE5NTISZFLGW7AUH36B5QUERZ3L7ILQQDA';
+      const error = new Error('Account not found');
+      mockServer.loadAccount.mockRejectedValue(error);
+
+      await expect(service.getAccount(accountId)).rejects.toThrow(
+        'Account not found',
+      );
+      expect(mockServer.loadAccount).toHaveBeenCalledWith(accountId);
     });
   });
 

--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -21,7 +21,6 @@ export class StellarService {
     return StrKey.isValidEd25519PublicKey(key);
   }
 
-  async submitTransaction(transaction: Parameters<Horizon.Server['submitTransaction']>[0]) {
   async submitTransaction(
     transaction: Parameters<Horizon.Server['submitTransaction']>[0],
   ) {


### PR DESCRIPTION
Closes #674

## Changes
- Fixed duplicate method signature syntax error in stellar.service.ts
- Added ConfigService provider to test module
- Properly mocked Horizon Server operations() method
- Added expectedDestination parameter to all verifyPayment test calls
- Added test cases for matching amount/destination, wrong amount, and wrong destination scenarios
- All 14 tests pass
closes #660
closes #674
closes #672
closes #655