### PR TITLE
chore: guard src/ against PHP and Symfony reintroduction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,32 @@ on:
 
 jobs:
   # -----------------------------------------------------------------------
+  # 0. Guard against non-NestJS projects under src/
+  # -----------------------------------------------------------------------
+  src-guard:
+    name: Source guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reject PHP and Composer files under src/
+        run: |
+          forbidden=$(git ls-files 'src/**/*.php' 'src/**/composer.json' 'src/**/composer.lock' || true)
+          if [ -n "$forbidden" ]; then
+            echo "Non-NestJS artifacts detected under src/:"
+            echo "$forbidden"
+            echo "This repo is TypeScript/NestJS only. Remove PHP or Symfony projects from src/."
+            exit 1
+          fi
+          echo "No forbidden artifacts under src/"
+
+  # -----------------------------------------------------------------------
   # 1. Lint
   # -----------------------------------------------------------------------
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: src-guard
     steps:
       - uses: actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Repository admins must configure the following branch protection settings on `ma
 2. Make your changes and write tests.
 3. Run checks locally before pushing:
    ```bash
+   npm run check:src-guard
    npm run lint
    npm run build
    npm run test
@@ -83,3 +84,6 @@ Each feature lives in its own folder under `src/`. To add a new feature:
 1. Create `src/my-feature/my-feature.module.ts`
 2. Add controllers, services, and DTOs inside that folder
 3. Register `MyFeatureModule` in the `imports` array of `src/app.module.ts`
+
+### Source directory (`src/`)
+This repository is a **NestJS / TypeScript** backend only. Do not add PHP, Symfony, or other non-TypeScript projects under `src/`. Feature code belongs in NestJS modules (`.module.ts`, `.controller.ts`, `.service.ts`, DTOs, etc.). CI rejects PHP and Composer artifacts under `src/`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "check:src-guard": "bash scripts/check-src-guard.sh",
     "seed": "ts-node -r tsconfig-paths/register src/database/seeds/seed.ts"
   },
   "dependencies": {

--- a/scripts/check-src-guard.sh
+++ b/scripts/check-src-guard.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+forbidden=$(git ls-files 'src/**/*.php' 'src/**/composer.json' 'src/**/composer.lock' || true)
+
+if [ -n "$forbidden" ]; then
+  echo "Non-NestJS artifacts detected under src/:" >&2
+  echo "$forbidden" >&2
+  echo "This repo is TypeScript/NestJS only. Remove PHP or Symfony projects from src/." >&2
+  exit 1
+fi
+
+echo "No forbidden artifacts under src/"


### PR DESCRIPTION
## Summary

Follow-up to #793. The misplaced Symfony PHP app (`src/CRUDAPI/`) was already removed from `main` in `b6c5ffc`. This PR adds guardrails so it cannot be accidentally reintroduced.

## Changes

- **CI** — new `Source guard` job in `.github/workflows/ci.yml` fails if PHP or Composer files appear under `src/`
- **Local script** — `npm run check:src-guard` runs the same check before pushing
- **Docs** — `CONTRIBUTING.md` clarifies that `src/` is NestJS/TypeScript only

## Why

`src/CRUDAPI/` was a full Symfony app committed inside a NestJS backend. It inflated repo size and confused contributors. The directory is gone, but nothing prevented it from coming back — this PR closes that gap.

## Test plan

- [ ] CI passes on this PR
- [ ] `npm run check:src-guard` passes on current `main`
- [ ] No existing NestJS files under `src/` are affected


closes: #793 