### PR TITLE
fix: resolve issues #720 #721 #722 #723 — validation, DB config, and student-auth constants

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -148,6 +148,7 @@ import { VerificationModule } from './verification/verification.module';
     AppCacheModule,
     // MongoDB connection — reads mongoUri from app.config.ts which maps MONGO_URI
     MongooseModule.forRootAsync({
+      imports: [ConfigModule],
       useFactory: (config: ConfigService) => ({
         uri: config.get<string>('mongoUri'),
         serverSelectionTimeoutMS: 5000,

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,7 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
       transform: true,
       transformOptions: { enableImplicitConversion: true },
+      stopAtFirstError: true,
     }),
   );
 

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -26,11 +26,11 @@ import {
   PasswordResetTokenDocument,
 } from './schemas/password-reset-token.schema';
 
-const ACCESS_TOKEN_EXPIRY = 3600;
-const REFRESH_TOKEN_EXPIRY = 604800;
-const BCRYPT_SALT_ROUNDS = 10;
+const ACCESS_TOKEN_EXPIRY = 3600; // 1 hour
+const REFRESH_TOKEN_EXPIRY = 604800; // 7 days
 const VERIFICATION_TOKEN_EXPIRY = 86400; // 24 hours
 const RESET_TOKEN_EXPIRY = 900; // 15 minutes
+const BCRYPT_SALT_ROUNDS = 10;
 const VERIFICATION_COOLDOWN = 60; // 1 minute cooldown between attempts
 const VERIFICATION_ATTEMPT_WINDOW = 900; // 15 minutes window for attempt counting
 const MAX_VERIFICATION_ATTEMPTS = 5; // Maximum 5 attempts per window

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -495,6 +495,10 @@ export class StudentAuthService {
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
 
+    if (payload.type !== 'refresh') {
+      throw new UnauthorizedException('Invalid token type');
+    }
+
     const tokenHash = this.hashToken(dto.refreshToken);
     const stored = await this.refreshTokenModel.findOne({ tokenHash }).exec();
 


### PR DESCRIPTION
## Summary

- **#723** — Added `stopAtFirstError: true` to the global `ValidationPipe` so validation halts on the first failing constraint per property, producing cleaner error payloads.
- **#722** — Added `imports: [ConfigModule]` to `MongooseModule.forRootAsync` to make the `ConfigService` dependency explicit and consistent with `ThrottlerModule` and `JwtModule`.
- **#721** — Added a `payload.type !== 'refresh'` guard in `refreshToken()` after JWT verification, preventing access tokens or other signed tokens from being replayed against the refresh endpoint.
- **#720** — Reordered top-level constants in `student-auth.service.ts` so all token-expiry values are grouped together before `BCRYPT_SALT_ROUNDS`, and added human-readable unit comments to every expiry constant.

## Closes

closes #720
closes #721
closes #722
closes #723

## Test plan

- [ ] POST with an invalid DTO body returns a single validation error per field (not a list of all violations)
- [ ] App connects to the correct MongoDB instance defined by `MONGO_URI` in `.env` in non-local environments
- [ ] POST `/auth/student/refresh` with an access token (not a refresh token) returns 401 with "Invalid token type"
- [ ] `student-auth.service.ts` compiles without errors; all `VERIFICATION_TOKEN_EXPIRY` references resolve correctly