### PR TITLE
fix(main): CORS, global prefix, Swagger env-gate, and compression middleware

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,8 @@ async function bootstrap() {
       .build();
 
     const document = SwaggerModule.createDocument(app, config);
-    SwaggerModule.setup('docs', app, document);
+    SwaggerModule.setup('api/docs', app, document);
+    console.log('Swagger UI available at /api/docs');
   }
 
   app.enableShutdownHooks();

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,12 +26,6 @@ async function bootstrap() {
   // Compress all responses
   app.use((compression as unknown as () => ReturnType<typeof compression>)());
 
-  // Global API prefix — exclude /health so load-balancers reach it without the prefix
-  app.setGlobalPrefix('api', { exclude: ['/health'] });
-
-  // URI-based versioning — controllers opt in with @Version(); existing routes are unaffected
-  app.enableVersioning({ type: VersioningType.URI });
-
   // Security headers
   app.use(helmet());
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,14 +17,13 @@ async function bootstrap() {
   app.setGlobalPrefix('api', { exclude: ['/health'] });
   app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
 
-  // Security headers (X-Content-Type-Options, X-Frame-Options, HSTS, etc.)
+  // Compress all responses — must be first so every subsequent handler sends compressed output
+  app.use((compression as unknown as () => ReturnType<typeof compression>)());
+
   // Body size limits for security
   const express = await import('express');
   app.use(express.json({ limit: '1mb' }));
   app.use(express.urlencoded({ limit: '1mb', extended: true }));
-
-  // Compress all responses
-  app.use((compression as unknown as () => ReturnType<typeof compression>)());
 
   // Security headers
   app.use(helmet());

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ async function bootstrap() {
     origin: process.env.ALLOWED_ORIGINS?.split(',') ?? ['http://localhost:3000'],
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
   });
 
   app.useGlobalPipes(


### PR DESCRIPTION
## Summary

- **#724** — Enable CORS with `ALLOWED_ORIGINS` env var, explicit methods, and allowed headers (`Content-Type`, `Authorization`, `X-Request-ID`)
- **#725** — Remove duplicate `setGlobalPrefix` and `enableVersioning` calls that were causing misconfiguration
- **#726** — Gate Swagger behind `NODE_ENV !== 'production'` and serve at `/api/docs` to avoid collision with the `/api` global prefix
- **#727** — Move `compression` middleware to first position so all responses (including body-parsed ones) are compressed

## Test plan

- [ ] Start the server in development — confirm `/api/docs` loads Swagger UI
- [ ] Start the server with `NODE_ENV=production` — confirm `/api/docs` returns 404
- [ ] Make a cross-origin request from `localhost:3000` — confirm no CORS errors in browser
- [ ] Verify response headers include `Content-Encoding: gzip` on a sizeable payload
- [ ] Confirm all routes are reachable under the `/api` prefix (e.g. `/api/student/login`)

Closes #724, closes #725, closes #726, closes #727