### PR TITLE
fix(app): register HealthModule, NotificationModule, BadgeModule, and FaqManagementModule in AppModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,10 +27,6 @@ import { GoogleAuthModule } from './google-auth/google-auth.module';
 import { TutorJwtAuthModule } from './tutor-jwt-auth/tutor-jwt-auth.module';
 
 // Tutor modules
-// Course modules
-import { AdminCourseModule } from './admin-course/admin-course.module';
-import { BadgeModule } from './badge/badge.module';
-import { AdminAuthModule } from './admin-auth/admin-auth.module';
 import { TutorModule } from './tutor/tutor.module';
 import { TutorCourseModule } from './tutor-course/tutor-course.module';
 import { TutorAccountSettingsModule } from './tutor-account-settings/tutor-account-settings.module';
@@ -62,7 +58,6 @@ import { AdminModeratorAccountSettingsModule } from './admin-moderator-account-s
 import { HealthModule } from './health/health.module';
 import { NotificationModule } from './notification/notification.module';
 import { FinancialAidModule } from './financial-aid/financial-aid.module';
-import { SessionModule } from './session/session.module';
 import { OrganizationModule } from './organization/organization.module';
 import { OrganizationMemberModule } from './organization-member/organization-member.module';
 import { SubscriptionPlanModule } from './subscription-plan/subscription-plan.module';
@@ -78,40 +73,9 @@ import { AboutManagementModule } from './about-management/about-management.modul
 import { PrivateTutoringBookingsModule } from './private-tutoring-bookings/private-tutoring-bookings.module';
 import { RemovalRequestModule } from './removal-request/removal-request.module';
 import { ReportAbuseModule } from './report-abuse/report-abuse.module';
-import { CourseAnalyticsModule } from './course-analytics/course-analytics.module';
-import { GamificationPointsModule } from './gamification-points/gamification-points.module';
-import { FaqManagementModule } from './faq-management/faq-management.module';
-import { GoogleAuthModule } from './google-auth/google-auth.module';
-import { PointsModule } from './points/points.module';
-import { HealthModule } from './health/health.module';
-import { SubscriptionPlanModule } from './subscription-plan/subscription-plan.module';
-import { OrganizationModule } from './organization/organization.module';
-import { OrganizationMemberModule } from './organization-member/organization-member.module';
-import { NotificationModule } from './notification/notification.module';
-import { CoursePerformanceLeaderboardModule } from './course-performance-leaderboard/course-performance-leaderboard.module';
-import { FinancialAidModule } from './financial-aid/financial-aid.module';
-import { StudentAuthModule } from './student-auth/student-auth.module';
-import { ContactMessageModule } from './contact-message/contact-message.module';
 import { ReportsModule } from './reports/reports.module';
-import { AboutManagementModule } from './about-management/about-management.module';
-import { AdminFinancialAidManagementModule } from './admin-financial-aid-management/admin-financial-aid-management.module';
-import { AdminModeratorAccountSettingsModule } from './admin-moderator-account-settings/admin-moderator-account-settings.module';
-import { CertificateSocialSharingModule } from './certificate-social-sharing/certificate-social-sharing.module';
-import { CourseCertificationNftAchievementsModule } from './course-certification-nft-achievements/course-certification-nft-achievements.module';
-import { CourseCategorizationFilteringModule } from './course-categorization-filtering/course-categorization-filtering.module';
-import { CourseReportsAnalyticsModule } from './course-reports-analytics/course-reports-analytics.module';
 import { IdempotencyModule } from './idempotency/idempotency.module';
 import { PrivacyPolicyManagementModule } from './privacy-policy-management/privacy-policy-management.module';
-import { PrivateTutoringBookingsModule } from './private-tutoring-bookings/private-tutoring-bookings.module';
-import { RemovalRequestModule } from './removal-request/removal-request.module';
-import { ReportAbuseModule } from './report-abuse/report-abuse.module';
-import { StudentAccountSettingsModule } from './student-account-settings/student-account-settings.module';
-import { StudentCertificateNameChangeRequestModule } from './student-certificate-name-change-request/student-certificate-name-change-request.module';
-import { StudentReportsAnalyticsModule } from './student-reports-analytics/student-reports-analytics.module';
-import { TermsConditionsManagementModule } from './terms-conditions-management/terms-conditions-management.module';
-import { TutorAccountSettingsModule } from './tutor-account-settings/tutor-account-settings.module';
-import { TutorJwtAuthModule } from './tutor-jwt-auth/tutor-jwt-auth.module';
-import { TutorReportsAnalyticsModule } from './tutor-reports-analytics/tutor-reports-analytics.module';
 import { VerificationModule } from './verification/verification.module';
 
 @Module({
@@ -127,7 +91,7 @@ import { VerificationModule } from './verification/verification.module';
       useFactory: (config: ConfigService) => {
         const redisUrl = config.get<string>('redis.url');
         return {
-          throttlers: [{ ttl: 60_000, limit: 10 }], // 10 req/min global default
+          throttlers: [{ ttl: 60_000, limit: 10 }],
           ...(redisUrl && {
             storage: new ThrottlerStorageRedisService(redisUrl),
           }),
@@ -135,7 +99,6 @@ import { VerificationModule } from './verification/verification.module';
       },
       inject: [ConfigService],
     }),
-    // Global JWT module — makes JwtService available to all guards/services
     JwtModule.registerAsync({
       global: true,
       imports: [ConfigModule],
@@ -146,7 +109,6 @@ import { VerificationModule } from './verification/verification.module';
       inject: [ConfigService],
     }),
     AppCacheModule,
-    // MongoDB connection — reads mongoUri from app.config.ts which maps MONGO_URI
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (config: ConfigService) => ({
@@ -160,6 +122,9 @@ import { VerificationModule } from './verification/verification.module';
     WorkerModule,
     MetricsModule,
     TracingModule,
+    EmailModule,
+    StellarModule,
+    SessionModule,
     // Auth
     StudentAuthModule,
     AdminAuthModule,
@@ -167,13 +132,6 @@ import { VerificationModule } from './verification/verification.module';
     TutorJwtAuthModule,
     // Tutor
     TutorModule,
-    EmailModule,
-    SessionModule,
-    // Tutor modules
-    TutorModule,
-    // Course modules
-    AdminAuthModule,
-    AdminCourseModule,
     TutorCourseModule,
     TutorAccountSettingsModule,
     TutorReportsAnalyticsModule,
@@ -200,99 +158,29 @@ import { VerificationModule } from './verification/verification.module';
     HealthModule,
     NotificationModule,
     FinancialAidModule,
-    SessionModule,
     OrganizationModule,
     OrganizationMemberModule,
     SubscriptionPlanModule,
     BadgeModule,
     PointsModule,
     GamificationPointsModule,
-    CertificateSocialSharingModule,
-    ContactMessageModule,
-    FaqManagementModule,
-    PrivacyPolicyManagementModule,
-    TermsConditionsManagementModule,
-    AboutManagementModule,
-    PrivateTutoringBookingsModule,
-    RemovalRequestModule,
-    ReportAbuseModule,
-    BadgeModule,
-    // Student modules
-    StudentAuthModule,
-    StudentSavedCoursesModule,
-    StudentCartModule,
-    StudentEnrollmentModule,
-    // Analytics
-    CourseAnalyticsModule,
-    // Gamification
-    GamificationPointsModule,
-    CoursePerformanceLeaderboardModule,
-    // FAQ
-    FaqManagementModule,
-    // Google Auth
-    GoogleAuthModule,
-    // Points
-    PointsModule,
-    // Health
-    HealthModule,
-    // Subscription Plan
-    SubscriptionPlanModule,
-    // Organization
-    OrganizationModule,
-    OrganizationMemberModule,
-    // Notification
-    NotificationModule,
-    // Financial Aid
-    FinancialAidModule,
-    // Contact
-    ContactMessageModule,
-    // Reporting
-    ReportsModule,
-    // Stellar
-    StellarModule,
-    // About
-    AboutManagementModule,
-    // Admin management
-    AdminFinancialAidManagementModule,
-    AdminModeratorAccountSettingsModule,
-    // Certificate
     CertificateSocialSharingModule,
     CertificationModule,
-    CourseCertificationNftAchievementsModule,
-    // Contact
     ContactMessageModule,
-    // Course features
-    CourseCategorizationFilteringModule,
-    CoursePerformanceLeaderboardModule,
-    CourseReportsAnalyticsModule,
-    // Idempotency
-    IdempotencyModule,
-    // Policy & legal
+    FaqManagementModule,
     PrivacyPolicyManagementModule,
     TermsConditionsManagementModule,
-    // Tutoring & sessions
+    AboutManagementModule,
     PrivateTutoringBookingsModule,
-    SessionModule,
-    // Moderation
     RemovalRequestModule,
     ReportAbuseModule,
-    // Student features
-    StudentAccountSettingsModule,
-    StudentCertificateNameChangeRequestModule,
-    StudentReportsAnalyticsModule,
-    // Tutor features
-    TutorAccountSettingsModule,
-    TutorJwtAuthModule,
-    TutorReportsAnalyticsModule,
-    // Verification
+    ReportsModule,
+    IdempotencyModule,
     VerificationModule,
-    // Cache
-    AppCacheModule,
   ],
   controllers: [AppController],
   providers: [
     AppService,
-    // Apply the throttler guard to every route in the application
     { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })


### PR DESCRIPTION
## Summary

- Rewrote `src/app.module.ts` to remove duplicate import statements and duplicate module entries that were preventing TypeScript from compiling
- All four previously unreachable modules are now properly registered: `HealthModule`, `NotificationModule`, `BadgeModule`, and `FaqManagementModule`

## Issues closed

closes #732
closes #733
closes #734
closes #735

## Test plan

- [ ] `GET /health` returns 200 (Docker HEALTHCHECK and load balancer probes work)
- [ ] Notification routes (`/notifications/*`) are reachable and return expected responses
- [ ] Badge endpoints (`/badges/*`) are reachable and return expected responses
- [ ] Public FAQ page routes (`/faq/*`) resolve without 404