### PR TITLE
fix: rename auth route paths in e2e tests to kebab-case

### DIFF
--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -374,9 +374,9 @@ describe('Student Auth – Full Journey (e2e)', () => {
   // Password reset
   // ---------------------------------------------------------------------------
   describe('Password reset flow', () => {
-    it('POST /student/forget/password returns success for any email (no oracle)', async () => {
+    it('POST /student/forgot-password returns success for any email (no oracle)', async () => {
       const res = await request(server)
-        .post('/student/forget/password')
+        .post('/student/forgot-password')
         .send({ email: BASE_EMAIL })
         .expect((r) => {
           if (r.status !== 200 && r.status !== 201) {
@@ -391,9 +391,9 @@ describe('Student Auth – Full Journey (e2e)', () => {
       expect(res.body.resetToken).toBeUndefined();
     });
 
-    it('POST /student/forget/password returns success even for an unknown email', async () => {
+    it('POST /student/forgot-password returns success even for an unknown email', async () => {
       const res = await request(server)
-        .post('/student/forget/password')
+        .post('/student/forgot-password')
         .send({ email: 'ghost@example.com' })
         .expect((r) => {
           if (r.status !== 200 && r.status !== 201) {
@@ -406,38 +406,38 @@ describe('Student Auth – Full Journey (e2e)', () => {
       expect(res.body.message).toMatch(/reset link/i);
     });
 
-    it('POST /student/forget/password rejects a missing email with 400', () =>
-      request(server).post('/student/forget/password').send({}).expect(400));
+    it('POST /student/forgot-password rejects a missing email with 400', () =>
+      request(server).post('/student/forgot-password').send({}).expect(400));
 
-    it('POST /student/reset/password rejects a missing body with 400', () =>
-      request(server).post('/student/reset/password').send({}).expect(400));
+    it('POST /student/reset-password rejects a missing body with 400', () =>
+      request(server).post('/student/reset-password').send({}).expect(400));
 
-    it('POST /student/reset/password rejects an invalid token with 400', () =>
+    it('POST /student/reset-password rejects an invalid token with 400', () =>
       request(server)
-        .post('/student/reset/password')
+        .post('/student/reset-password')
         .send({ token: 'bad-token', newPassword: 'NewPass123!' })
         .expect(400));
 
-    it('POST /student/reset/password rejects a short new password with 400', () =>
+    it('POST /student/reset-password rejects a short new password with 400', () =>
       request(server)
-        .post('/student/reset/password')
+        .post('/student/reset-password')
         .send({ token: 'sometoken', newPassword: 'short' })
         .expect(400));
 
-    it('POST /student/reset/password rejects an expired token with 400', async () => {
+    it('POST /student/reset-password rejects an expired token with 400', async () => {
       // Generate a fake expired token (this would fail validation)
       const res = await request(server)
-        .post('/student/reset/password')
+        .post('/student/reset-password')
         .send({ token: 'invalid-token-format', newPassword: 'NewSecurePass1!' })
         .expect(400);
 
       expect(res.body.message).toMatch(/invalid|expired/i);
     });
 
-    it('POST /student/reset/password rejects a used token (one-time use)', async () => {
+    it('POST /student/reset-password rejects a used token (one-time use)', async () => {
       // First, request a reset token
       await request(server)
-        .post('/student/forget/password')
+        .post('/student/forgot-password')
         .send({ email: BASE_EMAIL });
 
       // Get the token from database for testing
@@ -472,7 +472,7 @@ describe('Student Auth – Full Journey (e2e)', () => {
 
         // Use the token once
         await request(server)
-          .post('/student/reset/password')
+          .post('/student/reset-password')
           .send({
             token: resetTokenRecord.tokenHash,
             newPassword: 'TempPass123!',
@@ -481,7 +481,7 @@ describe('Student Auth – Full Journey (e2e)', () => {
 
         // Try to use it again - should fail
         const res = await request(server)
-          .post('/student/reset/password')
+          .post('/student/reset-password')
           .send({
             token: resetTokenRecord.tokenHash,
             newPassword: 'AnotherPass123!',
@@ -494,10 +494,10 @@ describe('Student Auth – Full Journey (e2e)', () => {
       }
     });
 
-    it('POST /student/reset/password resets the password with a valid token', async () => {
+    it('POST /student/reset-password resets the password with a valid token', async () => {
       // Request a new reset token
       await request(server)
-        .post('/student/forget/password')
+        .post('/student/forgot-password')
         .send({ email: BASE_EMAIL });
 
       // Get the token from database for testing
@@ -529,7 +529,7 @@ describe('Student Auth – Full Journey (e2e)', () => {
         }
 
         const res = await request(server)
-          .post('/student/reset/password')
+          .post('/student/reset-password')
           .send({
             token: resetTokenRecord.tokenHash,
             newPassword: 'NewSecurePass1!',


### PR DESCRIPTION
## Summary

Fixes the e2e test route paths to match the corrected controller route names, aligning with REST kebab-case conventions.

### Changes

Updated all route path strings in `test/auth.e2e-spec.ts` (21 occurrences):

- `/student/forget/password` → `/student/forgot-password`
- `/student/reset/password` → `/student/reset-password`

The controllers (`StudentAuthController` and `TutorController`) already expose the correct kebab-case routes. This PR brings the e2e tests in sync with those routes.

### Testing

All updated test descriptions and request paths now reflect the actual route names defined in the controllers.

Closes #767