### PR TITLE
fix(auth): standardize auth route paths — rename /create to /register

### DIFF
--- a/src/common/filters/http-exception.filter.spec.ts
+++ b/src/common/filters/http-exception.filter.spec.ts
@@ -97,7 +97,7 @@ describe('AllExceptionsFilter', () => {
     });
 
     it('formats ConflictException (409)', () => {
-      const { host, status, json } = buildHost('/student/create');
+      const { host, status, json } = buildHost('/auth/student/register');
       filter.catch(new ConflictException('Email already registered'), host);
 
       expect(status).toHaveBeenCalledWith(409);
@@ -105,7 +105,7 @@ describe('AllExceptionsFilter', () => {
         expect.objectContaining({
           statusCode: 409,
           message: 'Email already registered',
-          path: '/student/create',
+          path: '/auth/student/register',
         }),
       );
     });

--- a/src/tutor/tutor.controller.ts
+++ b/src/tutor/tutor.controller.ts
@@ -27,7 +27,7 @@ export class TutorController {
   constructor(private readonly tutorService: TutorService) {}
 
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
-  @Post('create')
+  @Post('register')
   @ApiOperation({ summary: 'Register a new tutor' })
   @ApiBody({ type: CreateTutorDto })
   @ApiResponse({ status: 201, description: 'Tutor registered. Verification email sent.' })

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -53,10 +53,10 @@ describe('Student Auth – Full Journey (e2e)', () => {
   // ---------------------------------------------------------------------------
   // Registration
   // ---------------------------------------------------------------------------
-  describe('POST /student/create', () => {
+  describe('POST /auth/student/register', () => {
     it('creates a new student and returns tokens (verification token sent via email)', async () => {
       const res = await request(server)
-        .post('/student/create')
+        .post('/auth/student/register')
         .send({
           firstName: 'Journey',
           lastName: 'Student',
@@ -87,7 +87,7 @@ describe('Student Auth – Full Journey (e2e)', () => {
 
     it('rejects a duplicate email with 409', () =>
       request(server)
-        .post('/student/create')
+        .post('/auth/student/register')
         .send({
           firstName: 'Dup',
           lastName: 'User',
@@ -98,13 +98,13 @@ describe('Student Auth – Full Journey (e2e)', () => {
 
     it('rejects missing required fields with 400', () =>
       request(server)
-        .post('/student/create')
+        .post('/auth/student/register')
         .send({ email: 'no-name@example.com', password: 'ValidPass1!' })
         .expect(400));
 
     it('rejects an invalid email format with 400', () =>
       request(server)
-        .post('/student/create')
+        .post('/auth/student/register')
         .send({
           firstName: 'A',
           lastName: 'B',
@@ -115,7 +115,7 @@ describe('Student Auth – Full Journey (e2e)', () => {
 
     it('rejects a password shorter than 8 characters with 400', () =>
       request(server)
-        .post('/student/create')
+        .post('/auth/student/register')
         .send({
           firstName: 'A',
           lastName: 'B',
@@ -131,7 +131,7 @@ describe('Student Auth – Full Journey (e2e)', () => {
   describe('POST /student/resend-verification-email', () => {
     it('sends a verification token for an unverified email', async () => {
       // First create a new unverified student
-      await request(server).post('/student/create').send({
+      await request(server).post('/auth/student/register').send({
         firstName: 'Verify',
         lastName: 'Student',
         email: VERIFICATION_EMAIL,

--- a/test/helpers/seed.helper.ts
+++ b/test/helpers/seed.helper.ts
@@ -36,7 +36,7 @@ export async function seedVerifiedStudent(
 ): Promise<SeededStudent> {
   const payload = { ...SEED_STUDENT, ...overrides };
 
-  const createRes = await request(server).post('/student/create').send(payload);
+  const createRes = await request(server).post('/auth/student/register').send(payload);
 
   if (createRes.status !== 201 && createRes.status !== 200) {
     throw new Error(


### PR DESCRIPTION
## Summary

Standardizes all auth registration route paths to follow REST conventions:
- `POST /tutor/create` → `POST /tutor/register`
- `POST /student/create` → `POST /auth/student/register` (controller was already correct; test references updated)

## Changes

### `src/tutor/tutor.controller.ts`
- Renamed `@Post('create')` to `@Post('register')` so the tutor registration endpoint is now `POST /tutor/register`.

### `test/auth.e2e-spec.ts`
- Updated describe block title from `POST /student/create` to `POST /auth/student/register`
- Updated all 6 route references from `/student/create` to `/auth/student/register` to match the existing `@Controller('auth/student')` + `@Post('register')` setup in `StudentAuthController`

### `test/helpers/seed.helper.ts`
- Updated `seedVerifiedStudent` helper to call `/auth/student/register` instead of `/student/create`

### `src/common/filters/http-exception.filter.spec.ts`
- Updated path string from `/student/create` to `/auth/student/register`

## Testing
- No logic changes; only route path rename and corresponding test/helper string updates.
- Unit tests (`npm run test`) and e2e tests (`npm run test:e2e`) should pass after this change.

Closes #766