### PR TITLE
feat: standardize API responses with ApiResponse wrapper and TransformInterceptor

### DIFF
--- a/src/common/dto/api-response.dto.ts
+++ b/src/common/dto/api-response.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Standard API response wrapper used across all endpoints.
+ * Every successful response is shaped as:
+ * { success: true, data: T, timestamp: string }
+ *
+ * The `message` field is optional and can carry a human-readable
+ * status message (e.g. "Course created successfully.").
+ */
+export class ApiResponse<T = unknown> {
+  @ApiProperty({
+    description: 'Indicates whether the request was successful',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Response payload',
+  })
+  data?: T;
+
+  @ApiPropertyOptional({
+    description: 'Human-readable status message',
+    example: 'Operation completed successfully.',
+  })
+  message?: string;
+
+  @ApiProperty({
+    description: 'ISO-8601 timestamp of when the response was generated',
+    example: '2024-01-01T00:00:00.000Z',
+  })
+  timestamp: string;
+
+  constructor(partial: Partial<ApiResponse<T>> = {}) {
+    this.success = partial.success ?? true;
+    this.data = partial.data;
+    this.message = partial.message;
+    this.timestamp = partial.timestamp ?? new Date().toISOString();
+  }
+}

--- a/src/common/interceptors/transform.interceptor.spec.ts
+++ b/src/common/interceptors/transform.interceptor.spec.ts
@@ -1,0 +1,102 @@
+import { ExecutionContext } from '@nestjs/common';
+import { of } from 'rxjs';
+import { TransformInterceptor } from './transform.interceptor';
+
+/** Helper that builds a minimal CallHandler returning the given value. */
+function buildCallHandler<T>(value: T) {
+  return {
+    handle: () => of(value),
+  };
+}
+
+/** Minimal ExecutionContext stub — TransformInterceptor does not read it. */
+const mockContext = {} as ExecutionContext;
+
+describe('TransformInterceptor', () => {
+  let interceptor: TransformInterceptor<unknown>;
+
+  beforeEach(() => {
+    interceptor = new TransformInterceptor();
+  });
+
+  // ── Shape guarantee ────────────────────────────────────────────────────────
+
+  it('wraps the response in { success, data, timestamp }', (done) => {
+    const payload = { id: 1, name: 'Alice' };
+    const handler = buildCallHandler(payload);
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(result).toMatchObject({
+        success: true,
+        data: payload,
+        timestamp: expect.any(String),
+      });
+      done();
+    });
+  });
+
+  it('sets success to true', (done) => {
+    const handler = buildCallHandler({ ok: true });
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(result.success).toBe(true);
+      done();
+    });
+  });
+
+  it('produces a valid ISO-8601 timestamp', (done) => {
+    const handler = buildCallHandler(null);
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(() => new Date(result.timestamp)).not.toThrow();
+      expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+      done();
+    });
+  });
+
+  it('passes null data through unchanged', (done) => {
+    const handler = buildCallHandler(null);
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(result.data).toBeNull();
+      done();
+    });
+  });
+
+  it('passes an array payload through unchanged', (done) => {
+    const items = [1, 2, 3];
+    const handler = buildCallHandler(items);
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(result.data).toEqual(items);
+      done();
+    });
+  });
+
+  it('passes an empty object through unchanged', (done) => {
+    const handler = buildCallHandler({});
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(result.data).toEqual({});
+      done();
+    });
+  });
+
+  it('does not include a message field in the envelope by default', (done) => {
+    const handler = buildCallHandler({ value: 42 });
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(result).not.toHaveProperty('message');
+      done();
+    });
+  });
+
+  it('passes string data through unchanged', (done) => {
+    const handler = buildCallHandler('hello');
+
+    interceptor.intercept(mockContext, handler).subscribe((result) => {
+      expect(result.data).toBe('hello');
+      done();
+    });
+  });
+});

--- a/src/common/interceptors/transform.interceptor.ts
+++ b/src/common/interceptors/transform.interceptor.ts
@@ -1,0 +1,37 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ApiResponse } from '../dto/api-response.dto';
+
+/**
+ * TransformInterceptor wraps every successful controller response in the
+ * standard {@link ApiResponse} envelope so the frontend `api-client.ts`
+ * can reliably parse all responses.
+ *
+ * Error responses are NOT touched here — they are handled by
+ * {@link AllExceptionsFilter} and already carry a consistent shape.
+ *
+ * Registration: `app.useGlobalInterceptors(new TransformInterceptor())` in main.ts
+ */
+@Injectable()
+export class TransformInterceptor<T>
+  implements NestInterceptor<T, ApiResponse<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<ApiResponse<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        success: true,
+        data,
+        timestamp: new Date().toISOString(),
+      })),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import * as compression from 'compression';
 import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/filters/http-exception.filter';
+import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 
 // Note: standalone src/express/ server has been removed — all routes are served by NestJS.
 async function bootstrap() {
@@ -47,6 +48,9 @@ async function bootstrap() {
   );
 
   app.useGlobalFilters(new AllExceptionsFilter());
+
+  // Wrap all successful responses in the standard ApiResponse envelope
+  app.useGlobalInterceptors(new TransformInterceptor());
 
   if (process.env.NODE_ENV !== 'production') {
     const config = new DocumentBuilder()


### PR DESCRIPTION
## Summary

Resolves #768

Different endpoints were returning inconsistent response shapes (raw Mongoose documents, `{ message: string }`, varied error shapes), making it impossible for the frontend `api-client.ts` to reliably parse responses.

## Changes

### `src/common/dto/api-response.dto.ts` (new)
Generic `ApiResponse<T>` DTO that wraps all successful responses:
```ts
{
  success: boolean;  // always true for successful responses
  data?: T;          // the actual payload
  message?: string;  // optional human-readable status message
  timestamp: string; // ISO-8601
}
```

### `src/common/interceptors/transform.interceptor.ts` (new)
`TransformInterceptor<T>` implements `NestInterceptor` and maps every controller return value into the `ApiResponse` envelope automatically — no per-controller changes required.

### `src/main.ts` (modified)
Registers the interceptor globally:
```ts
app.useGlobalInterceptors(new TransformInterceptor());
```
Error responses are untouched — they continue to be handled by the existing `AllExceptionsFilter` which already produces a consistent error shape.

### `src/common/interceptors/transform.interceptor.spec.ts` (new)
8 unit tests covering: envelope shape, `success: true` flag, valid ISO-8601 timestamp, and passthrough of `null`, array, empty object, and string data.

## Testing
```
PASS src/common/interceptors/transform.interceptor.spec.ts
  TransformInterceptor
    ✓ wraps the response in { success, data, timestamp }
    ✓ sets success to true
    ✓ produces a valid ISO-8601 timestamp
    ✓ passes null data through unchanged
    ✓ passes an array payload through unchanged
    ✓ passes an empty object through unchanged
    ✓ does not include a message field in the envelope by default
    ✓ passes string data through unchanged

Tests: 8 passed, 8 total
```

All 131 pre-existing TypeScript build errors remain unchanged — zero new errors introduced by this PR.