### PR TITLE
feat: Swagger decorators, ParseObjectIdPipe, request ID in errors

### DIFF
--- a/src/protocols/de-fi/de-fi.controller.ts
+++ b/src/protocols/de-fi/de-fi.controller.ts
@@ -12,6 +12,7 @@ import {
   HttpStatus,
   BadRequestException,
 } from "@nestjs/common";
+import { ApiBearerAuth } from "@nestjs/swagger";
 import { PositionTrackingService } from "./services/position-tracking.service";
 import { YieldOptimizationService } from "./services/yield-optimization.service";
 import { RiskAssessmentService } from "./services/risk-assessment.service";
@@ -39,6 +40,7 @@ import { User } from "src/core/user/entities/user.entity";
 import { CurrentUser } from "src/core/auth/decorators";
 import { ProtocolRegistry, ProtocolAdapterMetadata } from "./protocols/protocol-registry";
 
+@ApiBearerAuth('access-token')
 @Controller("defi")
 @UseGuards(JwtAuthGuard)
 export class DeFiController {

--- a/src/verification/verification.controller.ts
+++ b/src/verification/verification.controller.ts
@@ -29,7 +29,7 @@ export class VerificationController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
-  @ApiBearerAuth('JWT-auth')
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Verify a ticket code (organizer or admin only)' })
   @ApiResponse({ status: 200, description: 'Ticket is valid' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -61,7 +61,7 @@ export class VerificationController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
-  @ApiBearerAuth('JWT-auth')
+  @ApiBearerAuth('access-token')
   @ApiOperation({
     summary: 'Check in an attendee by ticket code (organizer or admin only)',
   })
@@ -112,7 +112,7 @@ export class VerificationController {
 
   @Get('stats/:eventId')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth('JWT-auth')
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Get verification statistics for an event' })
   @ApiParam({ name: 'eventId', type: String, description: 'Event UUID' })
   @ApiResponse({ status: 200, description: 'Verification statistics returned' })
@@ -126,7 +126,7 @@ export class VerificationController {
 
   @Get('logs/:eventId')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth('JWT-auth')
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Get all verification logs for an event' })
   @ApiParam({ name: 'eventId', type: String, description: 'Event UUID' })
   @ApiResponse({ status: 200, description: 'Verification logs returned' })


### PR DESCRIPTION
Implements four developer experience improvements.

## Changes

### #773 — @ApiBearerAuth on all protected controllers
Added `@ApiBearerAuth('access-token')` decorator to all controllers that use JwtAuthGuard. Swagger UI now shows the lock icon and allows testing authenticated endpoints.
- Added class-level `@ApiBearerAuth('access-token')` to `DeFiController` (protocols/de-fi)
- Standardized `VerificationController` to use `'access-token'` named scheme instead of `'JWT-auth'`, matching the Swagger config in main.ts

### #774 — Swagger documentation for StudentAuth endpoints
Verified all StudentAuth controller methods already have `@ApiOperation` and `@ApiResponse` decorators for complete Swagger documentation. No changes needed.

### #775 — ParseObjectIdPipe for MongoDB ObjectId validation
Verified `ParseObjectIdPipe` already exists at `src/common/pipes/parse-object-id.pipe.ts` with proper MongoDB ObjectId validation. No changes needed.

### #776 — Request ID in error responses
Verified `AllExceptionsFilter` already exists at `src/common/filters/http-exception.filter.ts` and is registered as a global filter in `main.ts`. It includes `requestId` from `RequestIdMiddleware` in all error responses. No changes needed.

Closes #773
Closes #774
Closes #775
Closes #776