### PR TITLE
fix: global JWT guard, @Public() decorator, OAuth tokens, notification security, /auth/me

### DIFF
--- a/src/about-management/about-management.controller.ts
+++ b/src/about-management/about-management.controller.ts
@@ -8,17 +8,20 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('about')
 export class AboutManagementController {
   constructor(private readonly service: AboutManagementService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -10,37 +10,37 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('admin/auth')
 export class AdminAuthController {
   constructor(private readonly service: AdminAuthService) {}
 
+  @Roles(Role.ADMIN)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
-  @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
+  @Post()
   create(@Body() payload: CreateAdminAuthDto) {
     return this.service.create(payload);
   }
 
-  @Patch(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
+  @Patch(':id')
   update(@Param('id', new ParseObjectIdPipe()) id: string, @Body() payload: UpdateAdminAuthDto) {
     return this.service.update(id, payload);
   }
 
+  @Roles(Role.ADMIN)
   @Delete(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ADMIN, Role.MODERATOR)
   remove(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.remove(id);
   }

--- a/src/admin-auth/admin-certificate-name-change-review/admin-certificate-name-change-review.controller.ts
+++ b/src/admin-auth/admin-certificate-name-change-review/admin-certificate-name-change-review.controller.ts
@@ -11,23 +11,25 @@ import { Roles } from '../../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('admin/certificates/name-change-review')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class AdminCertificateNameChangeReviewController {
   constructor(
     private readonly service: AdminCertificateNameChangeReviewService,
   ) {}
 
+  @Roles(Role.ADMIN, Role.MODERATOR)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN, Role.MODERATOR)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateAdminCertificateNameChangeReviewDto) {
     return this.service.create(payload);

--- a/src/admin-financial-aid-management/admin-financial-aid-management.controller.ts
+++ b/src/admin-financial-aid-management/admin-financial-aid-management.controller.ts
@@ -11,21 +11,23 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('admin/financial-aid')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class AdminFinancialAidManagementController {
   constructor(private readonly service: AdminFinancialAidManagementService) {}
 
+  @Roles(Role.ADMIN)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateAdminFinancialAidManagementDto) {
     return this.service.create(payload);

--- a/src/admin-moderator-account-settings/admin-moderator-account-settings.controller.ts
+++ b/src/admin-moderator-account-settings/admin-moderator-account-settings.controller.ts
@@ -11,21 +11,23 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('admin/moderator/account-settings')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class AdminModeratorAccountSettingsController {
   constructor(private readonly service: AdminModeratorAccountSettingsService) {}
 
+  @Roles(Role.ADMIN)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateAdminModeratorAccountSettingsDto) {
     return this.service.create(payload);

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { Public } from './common/decorators/public.decorator';
 
+@Public()
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { AppController } from './app.controller';
 import appConfig from './config/app.config';
 import { envValidationSchema } from './common/config/env.validation';
 import { AppService } from './app.service';
+import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { WorkerModule } from './worker/worker.module';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { MetricsModule } from './metrics/metrics.module';
@@ -187,6 +188,7 @@ import { VerificationModule } from './verification/verification.module';
   controllers: [AppController],
   providers: [
     AppService,
+    { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })

--- a/src/badge/badge.controller.ts
+++ b/src/badge/badge.controller.ts
@@ -8,22 +8,26 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('badges')
 export class BadgeController {
   constructor(private readonly service: BadgeService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
+  @Public()
   @Get('nft/:tokenId')
   findByNftTokenId(@Param('tokenId') tokenId: string) {
     return this.service.findByNftTokenId(tokenId);

--- a/src/certificate-social-sharing/certificate-social-sharing.controller.ts
+++ b/src/certificate-social-sharing/certificate-social-sharing.controller.ts
@@ -8,17 +8,20 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('certificates/social-sharing')
 export class CertificateSocialSharingController {
   constructor(private readonly service: CertificateSocialSharingService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);

--- a/src/certification/certification.controller.ts
+++ b/src/certification/certification.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Param, Res } from '@nestjs/common';
 import { Response } from 'express';
 import { CertificationService } from './certification.service';
+import { Public } from '../common/decorators/public.decorator';
 
+@Public()
 @Controller(['certification', 'v1/certification'])
 export class CertificationController {
   constructor(private readonly certificationService: CertificationService) {}

--- a/src/common/decorators/public.decorator.ts
+++ b/src/common/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -1,15 +1,26 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
   constructor(
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
+    private readonly reflector: Reflector,
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
     const request = context.switchToHttp().getRequest();
     const authHeader = request.headers?.authorization;
 

--- a/src/contact-message/contact-message.controller.ts
+++ b/src/contact-message/contact-message.controller.ts
@@ -8,37 +8,46 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
-@ApiBearerAuth('access-token')
 @Controller('contact-messages')
 export class ContactMessageController {
   constructor(private readonly service: ContactMessageService) {}
 
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN, Role.MODERATOR)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN, Role.MODERATOR)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
+  @Public()
   @Post()
   create(@Body() payload: CreateContactMessageDto) {
     return this.service.create(payload);
   }
 
-  @Patch(':id')
+  @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
+  @Patch(':id')
   update(@Param('id', new ParseObjectIdPipe()) id: string, @Body() payload: UpdateContactMessageDto) {
     return this.service.update(id, payload);
   }
 
-  @Delete(':id')
+  @ApiBearerAuth('access-token')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR)
+  @Delete(':id')
   remove(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.remove(id);
   }

--- a/src/course-categorization-filtering/course-categorization-filtering.controller.ts
+++ b/src/course-categorization-filtering/course-categorization-filtering.controller.ts
@@ -10,12 +10,14 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('courses/categorization-filtering')
 export class CourseCategorizationFilteringController {
   constructor(private readonly service: CourseCategorizationFilteringService) {}
 
+  @Public()
   @Get()
   @UseInterceptors(CacheInterceptor)
   @CacheKey('course-discovery')
@@ -36,6 +38,7 @@ export class CourseCategorizationFilteringController {
    *
    * Results are ordered by descending relevance score.
    */
+  @Public()
   @Get('search')
   @ApiOperation({
     summary: 'Full-text search and advanced course discovery',
@@ -55,6 +58,7 @@ export class CourseCategorizationFilteringController {
     return this.service.search(dto);
   }
 
+  @Public()
   @Get(':id')
   @UseInterceptors(CacheInterceptor)
   @CacheTTL(300000)

--- a/src/course-discovery/course-discovery.controller.ts
+++ b/src/course-discovery/course-discovery.controller.ts
@@ -3,7 +3,9 @@ import { ParseObjectIdPipe } from '../common/pipes/parse-object-id.pipe';
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { CourseDiscoveryService } from './course-discovery.service';
 import { SearchCoursesDto } from './dto/search-courses.dto';
+import { Public } from '../common/decorators/public.decorator';
 
+@Public()
 @ApiTags('Courses (Public)')
 @Controller('courses')
 export class CourseDiscoveryController {

--- a/src/course-performance-leaderboard/course-performance-leaderboard.controller.ts
+++ b/src/course-performance-leaderboard/course-performance-leaderboard.controller.ts
@@ -9,12 +9,14 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('courses/performance-leaderboard')
 export class CoursePerformanceLeaderboardController {
   constructor(private readonly service: CoursePerformanceLeaderboardService) {}
 
+  @Public()
   @Get()
   @UseInterceptors(CacheInterceptor)
   @CacheKey('leaderboard')
@@ -24,6 +26,7 @@ export class CoursePerformanceLeaderboardController {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   @UseInterceptors(CacheInterceptor)
   @CacheTTL(300000)

--- a/src/course-ratings-feedback/course-ratings-feedback.controller.ts
+++ b/src/course-ratings-feedback/course-ratings-feedback.controller.ts
@@ -8,6 +8,7 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('courses')
@@ -25,6 +26,7 @@ export class CourseRatingsFeedbackController {
     return this.service.create(courseId, req.user.id, payload);
   }
 
+  @Public()
   @Get(':id/ratings')
   findAllForCourse(@Param('id', new ParseObjectIdPipe()) courseId: string) {
     return this.service.findAllForCourse(courseId);

--- a/src/course-reports-analytics/course-reports-analytics.controller.ts
+++ b/src/course-reports-analytics/course-reports-analytics.controller.ts
@@ -11,21 +11,23 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('courses/reports-analytics')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class CourseReportsAnalyticsController {
   constructor(private readonly service: CourseReportsAnalyticsService) {}
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateCourseReportsAnalyticsDto) {
     return this.service.create(payload);

--- a/src/faq-management/faq-management.controller.ts
+++ b/src/faq-management/faq-management.controller.ts
@@ -9,12 +9,14 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('faq')
 export class FaqManagementController {
   constructor(private readonly service: FaqManagementService) {}
 
+  @Public()
   @Get()
   @UseInterceptors(CacheInterceptor)
   @CacheKey('/api/v1/faq')
@@ -24,6 +26,7 @@ export class FaqManagementController {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   @UseInterceptors(CacheInterceptor)
   @CacheTTL(600000)

--- a/src/gamification-points/gamification-points.controller.ts
+++ b/src/gamification-points/gamification-points.controller.ts
@@ -8,17 +8,20 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('gamification/points')
 export class GamificationPointsController {
   constructor(private readonly service: GamificationPointsService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);

--- a/src/google-auth/google-auth.controller.ts
+++ b/src/google-auth/google-auth.controller.ts
@@ -1,21 +1,24 @@
 import { Body, Controller, Post, Get, UseGuards, Req, Res } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Throttle } from '@nestjs/throttler';
 import { GoogleAuthService } from './google-auth.service';
 import { GoogleAuthDto } from './dto/google-auth.dto';
+import { Public } from '../common/decorators/public.decorator';
 
+@Public()
 @Controller()
 export class GoogleAuthController {
   constructor(private readonly service: GoogleAuthService) {}
 
-  @Post('student/register/google-auth')
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @Post('student/register/google-auth')
   @Post('register/google-auth')
   register(@Body() payload: GoogleAuthDto) {
     return this.service.register(payload);
   }
 
-  @Post('student/login/google-auth')
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @Post('student/login/google-auth')
   @Post('login/google-auth')
   login(@Body() payload: GoogleAuthDto) {
     return this.service.login(payload);

--- a/src/google-auth/google-auth.module.ts
+++ b/src/google-auth/google-auth.module.ts
@@ -3,7 +3,6 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { GoogleAuthController } from './google-auth.controller';
 import { GoogleAuthService } from './google-auth.service';
 import { GoogleUser, GoogleUserSchema } from './schemas/google-user.schema';
-import { StudentAuthModule } from '../student-auth/student-auth.module';
 import { GoogleStrategy } from './google.strategy';
 
 @Module({
@@ -11,7 +10,6 @@ import { GoogleStrategy } from './google.strategy';
     MongooseModule.forFeature([
       { name: GoogleUser.name, schema: GoogleUserSchema },
     ]),
-    StudentAuthModule,
   ],
   controllers: [GoogleAuthController],
   providers: [GoogleAuthService, GoogleStrategy],

--- a/src/google-auth/google-auth.service.ts
+++ b/src/google-auth/google-auth.service.ts
@@ -1,11 +1,9 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import * as crypto from 'crypto';
 import { GoogleAuthDto } from './dto/google-auth.dto';
 import { GoogleUser, GoogleUserDocument } from './schemas/google-user.schema';
-import { StudentAuthService } from '../student-auth/student-auth.service';
 
 const ACCESS_TOKEN_EXPIRY = 3600;
 
@@ -14,30 +12,14 @@ export class GoogleAuthService {
   constructor(
     @InjectModel(GoogleUser.name)
     private readonly googleUserModel: Model<GoogleUserDocument>,
-    private readonly configService: ConfigService,
-    private readonly authService: StudentAuthService,
+    private readonly jwtService: JwtService,
   ) {}
 
-  private get jwtSecret(): string {
-    return this.configService.get<string>('jwtSecret') ?? '';
-  }
-
-  private createJwt(
-    payload: Record<string, unknown>,
-    expiresIn: number,
-  ): string {
-    const header = Buffer.from(
-      JSON.stringify({ alg: 'HS256', typ: 'JWT' }),
-    ).toString('base64url');
-    const now = Math.floor(Date.now() / 1000);
-    const body = Buffer.from(
-      JSON.stringify({ ...payload, iat: now, exp: now + expiresIn }),
-    ).toString('base64url');
-    const sig = crypto
-      .createHmac('sha256', this.jwtSecret)
-      .update(`${header}.${body}`)
-      .digest('base64url');
-    return `${header}.${body}.${sig}`;
+  private createAccessToken(user: GoogleUserDocument): string {
+    return this.jwtService.sign(
+      { sub: user.id, email: user.email, role: user.role },
+      { expiresIn: ACCESS_TOKEN_EXPIRY },
+    );
   }
 
   async register(
@@ -54,7 +36,9 @@ export class GoogleAuthService {
 
     const user = await new this.googleUserModel(payload).save();
 
-    return this.authService.generateTokenPair(user.id, user.email, user.role);
+    const accessToken = this.createAccessToken(user);
+
+    return { accessToken, expiresIn: ACCESS_TOKEN_EXPIRY };
   }
 
   async login(
@@ -71,6 +55,8 @@ export class GoogleAuthService {
       throw new NotFoundException('User not found. Please register first.');
     }
 
-    return this.authService.generateTokenPair(user.id, user.email, user.role);
+    const accessToken = this.createAccessToken(user);
+
+    return { accessToken, expiresIn: ACCESS_TOKEN_EXPIRY };
   }
 }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get, HttpStatus, Res } from '@nestjs/common';
 import type { Response } from 'express';
 import { HealthService } from './health.service';
+import { Public } from '../common/decorators/public.decorator';
 
 /**
  * GET /health       – liveness probe (always 200 while the process is running)
  * GET /health/ready – readiness probe (503 when a configured dependency is unreachable)
  */
+@Public()
 @Controller('health')
 export class HealthController {
   constructor(private readonly healthService: HealthService) {}

--- a/src/metrics/metrics.controller.ts
+++ b/src/metrics/metrics.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Header, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MetricsService } from './metrics.service';
 import { InternalOnlyGuard } from './internal-only.guard';
+import { Public } from '../common/decorators/public.decorator';
 
+@Public()
 @ApiTags('Observability')
 @Controller('metrics')
 @UseGuards(InternalOnlyGuard)

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -46,6 +46,8 @@ export class NotificationController {
   }
 
   @Get(':id')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }

--- a/src/observability/profiling.controller.ts
+++ b/src/observability/profiling.controller.ts
@@ -12,13 +12,11 @@ import { Response } from 'express';
 import { createReadStream, existsSync } from 'fs';
 import { join } from 'path';
 import { Public } from '../common/decorators/public.decorator';
-import { SkipKyc } from '../common/decorators/skip-kyc.decorator';
 import { ProfilingService } from './profiling.service';
 
 @ApiTags('Profiling')
 @Controller('profiling')
 @Public()
-@SkipKyc()
 export class ProfilingController {
   constructor(private readonly profilingService: ProfilingService) {}
 

--- a/src/organization/organization.controller.ts
+++ b/src/organization/organization.controller.ts
@@ -8,17 +8,20 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('organizations')
 export class OrganizationController {
   constructor(private readonly service: OrganizationService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);

--- a/src/privacy-policy-management/privacy-policy-management.controller.ts
+++ b/src/privacy-policy-management/privacy-policy-management.controller.ts
@@ -9,12 +9,14 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('privacy-policy')
 export class PrivacyPolicyManagementController {
   constructor(private readonly service: PrivacyPolicyManagementService) {}
 
+  @Public()
   @Get()
   @UseInterceptors(CacheInterceptor)
   @CacheKey('privacy-policy')
@@ -24,6 +26,7 @@ export class PrivacyPolicyManagementController {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   @UseInterceptors(CacheInterceptor)
   @CacheTTL(3600000)

--- a/src/private-tutoring-bookings/private-tutoring-bookings.controller.ts
+++ b/src/private-tutoring-bookings/private-tutoring-bookings.controller.ts
@@ -8,17 +8,20 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('tutoring/bookings')
 export class PrivateTutoringBookingsController {
   constructor(private readonly service: PrivateTutoringBookingsService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { ReportsService } from './reports.service';
+import { Public } from '../common/decorators/public.decorator';
 
+@Public()
 @Controller('reports')
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}

--- a/src/stellar/stellar.controller.ts
+++ b/src/stellar/stellar.controller.ts
@@ -10,12 +10,14 @@ import { IsStellarPublicKey } from '../common/validators/is-stellar-public-key.v
 import { StellarService } from './stellar.service';
 import { VerifyPaymentDto } from './dto/verify-payment.dto';
 import { CreateAccountResponseDto } from './dto/create-account-response.dto';
+import { Public } from '../common/decorators/public.decorator';
 
 export class WalletPublicKeyDto {
   @Validate(IsStellarPublicKey)
   publicKey: string;
 }
 
+@Public()
 @ApiTags('Stellar')
 @Controller('stellar')
 export class StellarController {

--- a/src/student-account-settings/student-account-settings.controller.ts
+++ b/src/student-account-settings/student-account-settings.controller.ts
@@ -11,21 +11,23 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('student/account-settings')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class StudentAccountSettingsController {
   constructor(private readonly service: StudentAccountSettingsService) {}
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateStudentAccountSettingsDto) {
     return this.service.create(payload);

--- a/src/student-auth/student-auth.controller.ts
+++ b/src/student-auth/student-auth.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
-import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { StudentAuthService } from './student-auth.service';
 import { CreateStudentDto } from './dto/create-student.dto';
@@ -9,6 +9,8 @@ import { ResendVerificationEmailDto } from './dto/resend-verification-email.dto'
 import { ForgetPasswordDto } from './dto/forget-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { Public } from '../common/decorators/public.decorator';
 
 // Auth endpoints are more sensitive to brute-force: tighten to 10 req/min
 @Throttle({ default: { limit: 10, ttl: 60_000 } })
@@ -17,7 +19,18 @@ import { RefreshTokenDto } from './dto/refresh-token.dto';
 export class StudentAuthController {
   constructor(private readonly studentAuthService: StudentAuthService) {}
 
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtAuthGuard)
+  @Get('me')
+  @ApiOperation({ summary: 'Get authenticated student profile' })
+  @ApiResponse({ status: 200, description: 'Returns the authenticated student profile' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async me(@Req() req: any) {
+    return this.studentAuthService.findStudentById(req.user.sub);
+  }
+
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @Public()
   @Post('register')
   @ApiOperation({ summary: 'Register a new student' })
   @ApiBody({ type: CreateStudentDto })
@@ -28,6 +41,7 @@ export class StudentAuthController {
     return this.studentAuthService.create(dto);
   }
 
+  @Public()
   @Post('verify-email')
   @ApiOperation({ summary: 'Verify student email with token' })
   @ApiBody({ type: VerifyEmailDto })
@@ -37,6 +51,7 @@ export class StudentAuthController {
     return this.studentAuthService.verifyEmail(dto);
   }
 
+  @Public()
   @Post('resend-verification-email')
   @ApiOperation({ summary: 'Resend email verification link' })
   @ApiBody({ type: ResendVerificationEmailDto })
@@ -53,6 +68,7 @@ export class StudentAuthController {
   }
 
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @Public()
   @Post('login')
   @ApiOperation({ summary: 'Authenticate a student and receive tokens' })
   @ApiBody({ type: LoginStudentDto })
@@ -70,6 +86,7 @@ export class StudentAuthController {
   }
 
   @Throttle({ default: { limit: 3, ttl: 900_000 } }) // 3 per 15 minutes
+  @Public()
   @Post('forgot-password')
   @ApiOperation({ summary: 'Request a password reset link' })
   @ApiBody({ type: ForgetPasswordDto })
@@ -86,6 +103,7 @@ export class StudentAuthController {
     );
   }
 
+  @Public()
   @Post('reset-password')
   @ApiOperation({ summary: 'Reset password using a valid reset token' })
   @ApiBody({ type: ResetPasswordDto })
@@ -102,6 +120,7 @@ export class StudentAuthController {
     );
   }
 
+  @Public()
   @Post('refresh-token')
   @ApiOperation({ summary: 'Rotate refresh token and get a new token pair' })
   @ApiBody({ type: RefreshTokenDto })
@@ -114,6 +133,7 @@ export class StudentAuthController {
     return this.studentAuthService.refreshToken(dto);
   }
 
+  @Public()
   @Post('logout')
   @ApiOperation({ summary: 'Invalidate the current refresh token' })
   @ApiBody({ type: RefreshTokenDto })

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -119,6 +119,14 @@ export class StudentAuthService {
     };
   }
 
+  async findStudentById(studentId: string) {
+    const student = await this.studentModel.findById(studentId).exec();
+    if (!student) {
+      throw new NotFoundException('Student not found');
+    }
+    return this.sanitizeStudent(student);
+  }
+
   async create(dto: CreateStudentDto) {
     if (!dto.firstName || !dto.lastName || !dto.email || !dto.password) {
       throw new BadRequestException(

--- a/src/student-certificate-name-change-request/student-certificate-name-change-request.controller.ts
+++ b/src/student-certificate-name-change-request/student-certificate-name-change-request.controller.ts
@@ -11,23 +11,25 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('student/certificates/name-change-request')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class StudentCertificateNameChangeRequestController {
   constructor(
     private readonly service: StudentCertificateNameChangeRequestService,
   ) {}
 
+  @Roles(Role.ADMIN, Role.MODERATOR)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN, Role.MODERATOR)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateStudentCertificateNameChangeRequestDto) {
     return this.service.create(payload);

--- a/src/subscription-plan/subscription-plan.controller.ts
+++ b/src/subscription-plan/subscription-plan.controller.ts
@@ -8,17 +8,20 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('subscription-plans')
 export class SubscriptionPlanController {
   constructor(private readonly service: SubscriptionPlanService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);

--- a/src/terms-conditions-management/terms-conditions-management.controller.ts
+++ b/src/terms-conditions-management/terms-conditions-management.controller.ts
@@ -8,17 +8,20 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('terms-conditions')
 export class TermsConditionsManagementController {
   constructor(private readonly service: TermsConditionsManagementService) {}
 
+  @Public()
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);

--- a/src/tutor-account-settings/tutor-account-settings.controller.ts
+++ b/src/tutor-account-settings/tutor-account-settings.controller.ts
@@ -11,21 +11,23 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('tutor/account-settings')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class TutorAccountSettingsController {
   constructor(private readonly service: TutorAccountSettingsService) {}
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateTutorAccountSettingsDto) {
     return this.service.create(payload);

--- a/src/tutor-jwt-auth/tutor-jwt-auth.controller.ts
+++ b/src/tutor-jwt-auth/tutor-jwt-auth.controller.ts
@@ -11,28 +11,29 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('tutor/jwt-auth')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class TutorJwtAuthController {
   constructor(private readonly service: TutorJwtAuthService) {}
 
+  @Roles(Role.ADMIN)
   @Get()
   async findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN)
   @Get(':id')
   async findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   async create(@Body() payload: CreateTutorJwtAuthDto) {
     return this.service.create(payload);
   }
 
   @Patch(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   async update(
     @Param('id', new ParseObjectIdPipe()) id: string,
@@ -42,7 +43,6 @@ export class TutorJwtAuthController {
   }
 
   @Delete(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR)
   async remove(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.remove(id);

--- a/src/tutor-reports-analytics/tutor-reports-analytics.controller.ts
+++ b/src/tutor-reports-analytics/tutor-reports-analytics.controller.ts
@@ -11,21 +11,23 @@ import { Roles } from '../common/decorators/roles.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('tutor/reports-analytics')
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class TutorReportsAnalyticsController {
   constructor(private readonly service: TutorReportsAnalyticsService) {}
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get()
   findAll() {
     return this.service.findAll();
   }
 
+  @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Get(':id')
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   create(@Body() payload: CreateTutorReportsAnalyticsDto) {
     return this.service.create(payload);

--- a/src/tutor/tutor.controller.ts
+++ b/src/tutor/tutor.controller.ts
@@ -20,6 +20,7 @@ import { ResetTutorPasswordDto } from './dto/reset-tutor-password.dto';
 import { UpdateTutorProfileDto } from './dto/update-tutor-profile.dto';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('Tutor Auth')
 @Controller('tutor')
@@ -27,6 +28,7 @@ export class TutorController {
   constructor(private readonly tutorService: TutorService) {}
 
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @Public()
   @Post('register')
   @ApiOperation({ summary: 'Register a new tutor' })
   @ApiBody({ type: CreateTutorDto })
@@ -37,6 +39,7 @@ export class TutorController {
   }
 
   @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @Public()
   @Post('login')
   @ApiOperation({ summary: 'Authenticate a tutor and receive tokens' })
   @ApiBody({ type: LoginTutorDto })
@@ -47,6 +50,7 @@ export class TutorController {
     return this.tutorService.login(dto);
   }
 
+  @Public()
   @Post('verify-email')
   @ApiOperation({ summary: 'Verify tutor email with token' })
   @ApiBody({ type: VerifyTutorEmailDto })
@@ -57,6 +61,7 @@ export class TutorController {
   }
 
   @Throttle({ default: { limit: 3, ttl: 900_000 } }) // 3 per 15 minutes
+  @Public()
   @Post('forgot-password')
   @ApiOperation({ summary: 'Request a password reset link' })
   @ApiBody({ type: ForgetTutorPasswordDto })
@@ -70,6 +75,7 @@ export class TutorController {
     );
   }
 
+  @Public()
   @Post('reset-password')
   @ApiOperation({ summary: 'Reset password using a valid reset token' })
   @ApiBody({ type: ResetTutorPasswordDto })
@@ -83,6 +89,7 @@ export class TutorController {
     );
   }
 
+  @Public()
   @Post('refresh-token')
   @ApiOperation({ summary: 'Rotate tutor refresh token and issue a new token pair' })
   @ApiBody({ type: RefreshTokenDto })
@@ -92,6 +99,7 @@ export class TutorController {
     return this.tutorService.refreshToken(dto);
   }
 
+  @Public()
   @Post('logout')
   @ApiOperation({ summary: 'Revoke the current tutor refresh token' })
   @ApiBody({ type: RefreshTokenDto })

--- a/src/verification/verification.controller.ts
+++ b/src/verification/verification.controller.ts
@@ -14,6 +14,7 @@ import { Roles } from '../auth/decorators/roles.decorators';
 import { CurrentUser } from '../auth/decorators/current.user.decorators';
 import { UserRole } from '../auth/common/enum/user-role-enum';
 import { User } from '../auth/entities/user.entity';
+import { Public } from '../common/decorators/public.decorator';
 import type {
   VerificationResult,
   VerificationStats,
@@ -89,6 +90,7 @@ export class VerificationController {
     return result;
   }
 
+  @Public()
   @Get('peek/:ticketCode')
   @ApiOperation({
     summary: 'Preview ticket validity without marking it as used (public)',

--- a/src/worker/worker.controller.ts
+++ b/src/worker/worker.controller.ts
@@ -5,6 +5,7 @@ import { extname } from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { WorkerService } from './worker.service';
 import { UploadWorkerFileDto } from './dto/upload-worker-file.dto';
+import { Public } from '../common/decorators/public.decorator';
 
 interface MulterFile {
   originalname: string;
@@ -15,6 +16,7 @@ interface MulterFile {
 
 const uploadDirectory = 'uploads/worker';
 
+@Public()
 @Controller('worker')
 export class WorkerController {
   constructor(private readonly workerService: WorkerService) {}


### PR DESCRIPTION


Issues fixed:
- Closes #788: Google OAuth broken generateTokenPair calls replaced with JwtService.sign()
- Closes #789: notification findOne endpoint now requires ADMIN role via RolesGuard
- Closes #790: GET /auth/student/me endpoint added for authenticated student profile lookup
- Closes #791: JwtAuthGuard applied globally via APP_GUARD; @Public() decorator introduced for all public/unauthenticated endpoints across every controller

Other improvements:
- Removed StudentAuthModule dependency from GoogleAuthModule
- Removed broken SkipKyc import from profiling.controller.ts
- Added role guards to previously unprotected admin/tutor settings endpoints
- contact-message create is now @Public(); admin/moderator endpoints properly guarded
- admin-auth findAll/findOne restricted to ADMIN role
- tutor-jwt-auth findAll/findOne restricted to ADMIN role

## What does this PR do?

<!-- Provide a clear summary of the changes and why they are needed. -->

## Related issue(s)

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How has this been tested?

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing

## Checklist

- [ ] Tests pass locally
- [ ] Swagger docs updated
- [ ] `.env.example` updated (if new env vars added)
