### PR TITLE
security: audit logging, upload quarantine, org-scoped authz

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,40 @@ CONTRACT_CERTIFICATES=
 CONTRACT_REWARD=
 CONTRACT_CHV_TOKEN=
 CONTRACT_COURSE_REGISTRY=
+
+# ─── Audit logging (privileged action trail) ──────────────────────────────────
+# Dedicated HMAC key for audit-entry integrity hashes. Optional: falls back to
+# JWT_SECRET when unset, but set it in production — sharing the key means
+# rotating JWT_SECRET invalidates the integrity hash of every historical entry.
+# Generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+AUDIT_HMAC_SECRET=
+
+# When true, a failed audit write also fails the mutation being audited.
+# Default false: an audit outage does not break privileged operations.
+AUDIT_LOG_FAIL_CLOSED=false
+
+# ─── Uploads: quarantine, scanning and quotas ─────────────────────────────────
+# Storage root for uploaded files. MUST stay outside any web-served directory.
+# Files land in <root>/quarantine first and only reach <root>/clean after a scan.
+UPLOAD_STORAGE_ROOT=var/uploads
+
+# Maximum accepted size of a single upload, in bytes (default: 5 MiB)
+UPLOAD_MAX_FILE_BYTES=5242880
+
+# Per-user quotas: total stored bytes, and file count per rolling window
+UPLOAD_QUOTA_MAX_BYTES=104857600
+UPLOAD_QUOTA_MAX_FILES=20
+UPLOAD_QUOTA_WINDOW_MS=86400000
+
+# Keep infected samples under <root>/infected instead of deleting them.
+# Enable only if you have a forensics process; the bytes are still malware.
+UPLOAD_RETAIN_INFECTED=false
+
+# Malware scanner backend: builtin | clamav
+#   builtin — EICAR + active-content heuristics, no external dependency
+#   clamav  — streams uploads to a clamd daemon over TCP (INSTREAM)
+MALWARE_SCAN_PROVIDER=builtin
+MALWARE_SCAN_HOST=127.0.0.1
+MALWARE_SCAN_PORT=3310
+MALWARE_SCAN_TIMEOUT_MS=30000

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ build/
 
 # Local scratch files
 *.scratch.ts
+
+# Upload storage root (quarantine / clean / infected)
+var/
+uploads/

--- a/README.md
+++ b/README.md
@@ -122,10 +122,28 @@ Supported roles:
 * `TUTOR`
 * `STUDENT`
 
+### 🏢 Organization-Scoped Roles
+
+Global roles describe what a user is on the platform. Membership in an
+organization is a separate axis with its own roles:
+
+* `owner` · `admin` · `instructor` · `member`
+
+Holding a role in one organization grants nothing in another. See
+[docs/security/organization-authorization.md](docs/security/organization-authorization.md).
+
 ### 🔒 Guards
 
 * `JwtAuthGuard` → validates authenticated users
-* `RolesGuard` → enforces role-based permissions
+* `RolesGuard` → enforces platform role-based permissions
+* `OrganizationRolesGuard` → enforces organization membership roles
+
+### 📝 Security Documentation
+
+* [Immutable audit logging](docs/security/audit-logging.md) — append-only trail
+  for privileged actions
+* [Organization-scoped authorization](docs/security/organization-authorization.md)
+* [Upload quarantine and malware scanning](docs/security/uploads.md)
 
 ---
 

--- a/docs/security/audit-logging.md
+++ b/docs/security/audit-logging.md
@@ -1,0 +1,131 @@
+# Immutable audit logging for privileged actions
+
+Course review, financial-aid decisions, moderation and account administration
+now share a single append-only audit trail stored in the `audit_logs`
+collection.
+
+Implementation lives in [`src/common/audit`](../../src/common/audit).
+
+## What is recorded
+
+Every entry carries the fields the acceptance criteria call for:
+
+| Field           | Meaning                                                            |
+| --------------- | ------------------------------------------------------------------ |
+| `action`        | Namespaced verb from `AuditAction`, e.g. `course.reviewed`          |
+| `actor`         | `{ id, email, role, ip, userAgent }` of the caller                  |
+| `target`        | `{ type, id }` of the object acted on                               |
+| `requestId`     | Correlation ID from `X-Request-Id` (set by `RequestIdMiddleware`)   |
+| `timestamp`     | When the action happened                                            |
+| `recordedAt`    | When the entry was stored (schema timestamp)                        |
+| `outcome`       | `success`, `failure` or `denied`                                    |
+| `before`        | Redacted state before the mutation (`null` for creations)           |
+| `after`         | Redacted state after the mutation (`null` for deletions)            |
+| `reason`        | Operator-supplied justification, where the endpoint collects one    |
+| `integrityHash` | HMAC-SHA256 over the canonical entry                                |
+
+## Covered actions
+
+| Area                              | Actions                                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------------------------- |
+| `src/admin-course`                | `course.reviewed`, `course.published`, `course.unpublished`, `course.updated`, `course.deleted` |
+| `src/admin-financial-aid-management` | `financial_aid.created`, `financial_aid.updated`, `financial_aid.deleted`                |
+| `src/admin-auth`                  | `admin_account.created`, `admin_account.updated`, `admin_account.deleted`                    |
+| `src/report-abuse`                | `abuse_report.updated`, `abuse_report.deleted`                                               |
+| `src/organization`, `src/organization-member` | `organization.*`, `organization_member.*`                                        |
+| `src/worker`                      | `file_upload.quarantined`, `file_upload.scanned`, `file_upload.released`, `file_upload.rejected`, `file_upload.deleted` |
+
+Course actions are audited only when performed by an admin. A tutor editing
+their own course is ordinary authorship, not a privileged action.
+
+## How immutability is enforced
+
+Three independent layers, so no single bypass is enough:
+
+1. **Query middleware** — `applyAuditImmutability` registers `pre` hooks that
+   throw `AuditLogImmutableError` for `updateOne`, `updateMany`, `replaceOne`,
+   `findOneAndUpdate`, `findOneAndReplace`, `findOneAndDelete`,
+   `findOneAndRemove`, `deleteOne`, `deleteMany`, `remove` and `bulkWrite`.
+2. **Document middleware** — `pre('save')` rejects saving a document that is not
+   `isNew`, so an entry cannot be loaded, edited and re-saved.
+3. **Integrity hash** — `integrityHash` is an HMAC over the canonical
+   (key-sorted) entry. Tampering performed outside the application, for example
+   a direct `mongosh` write, is detectable with `AuditService.verify(entry)`.
+
+Application-level guards do not stop a database administrator. For a genuinely
+tamper-proof trail, pair this with a database role that lacks `update` and
+`delete` privileges on `audit_logs`, and ship entries to append-only storage.
+
+## Redaction
+
+Everything written to `before`/`after` passes through `redactMetadata`:
+
+- Values under sensitive keys (`password`, `token`, `secret`, `authorization`,
+  `apiKey`, `ssn`, `cardNumber`, `mnemonic`, …) become `[REDACTED]`. Key
+  matching is case-insensitive and separator-insensitive, so `card_number`,
+  `card-number` and `cardNumber` are all caught.
+- Email addresses are masked to `a***@example.com`, so an auditor can correlate
+  accounts without the collection becoming a harvestable address list.
+- Strings over 512 characters are truncated, arrays capped at 20 entries,
+  objects capped at 50 keys, nesting capped at depth 5, and cycles broken.
+
+## Configuration
+
+| Variable                | Default | Purpose                                                       |
+| ----------------------- | ------- | ------------------------------------------------------------- |
+| `AUDIT_HMAC_SECRET`     | unset   | Dedicated HMAC key. Falls back to `JWT_SECRET` when unset.    |
+| `AUDIT_LOG_FAIL_CLOSED` | `false` | When `true`, a failed audit write fails the mutation as well. |
+
+`AUDIT_HMAC_SECRET` is optional so existing deployments keep working, but set it
+in production: sharing the key with `JWT_SECRET` means rotating that secret
+invalidates the integrity hash of every historical entry. `AuditService` logs a
+warning at startup when it is missing in production.
+
+`AUDIT_LOG_FAIL_CLOSED` defaults to `false` so an audit outage cannot fail an
+otherwise successful privileged mutation. Set it to `true` where a missing audit
+record is worse than a failed operation.
+
+## API behaviour
+
+No request or response shape changes. Audited handlers gain an `@AuditActor()`
+parameter, which is resolved server-side from the authenticated principal and
+request headers — it is not client-supplied.
+
+## Usage
+
+```ts
+// Controller: resolve the actor from the request
+@Patch(':id')
+update(
+  @Param('id') id: string,
+  @Body() dto: UpdateDto,
+  @AuditActor() audit: AuditContext,
+) {
+  return this.service.update(id, dto, audit);
+}
+
+// Service: record around the mutation
+const before = snapshot(existing, AUDIT_FIELDS);
+const updated = await this.model.findByIdAndUpdate(id, dto, { new: true });
+
+await this.auditService.record({
+  action: AuditAction.ABUSE_REPORT_UPDATED,
+  context: audit ?? systemAuditContext(),
+  target: { type: 'abuse_report', id },
+  before,
+  after: snapshot(updated, AUDIT_FIELDS),
+});
+```
+
+Background jobs and other non-HTTP callers use `systemAuditContext()`.
+
+## Tests
+
+- `src/common/audit/audit.service.spec.ts` — entry shape, redaction, integrity
+  hash verification and tamper detection, fail-open/fail-closed
+- `src/common/audit/audit-redaction.spec.ts` — redaction rules and limits
+- `src/common/audit/audit-context.spec.ts` — actor resolution
+- `src/common/audit/schemas/audit-log.schema.spec.ts` — append-only guards
+- `src/admin-course/admin-course.audit.spec.ts`,
+  `src/admin-auth/admin-auth.service.spec.ts`,
+  `src/report-abuse/report-abuse.service.spec.ts` — per-domain wiring

--- a/docs/security/organization-authorization.md
+++ b/docs/security/organization-authorization.md
@@ -1,0 +1,141 @@
+# Organization-scoped authorization
+
+Global roles (`admin`, `moderator`, `tutor`, `student`) describe what someone is
+on the platform. They cannot express what someone is *inside* a particular
+organization. This adds a second, orthogonal axis.
+
+Implementation: [`OrganizationRolesGuard`](../../src/common/guards/organization-roles.guard.ts),
+[`OrganizationRole`](../../src/common/enums/organization-role.enum.ts),
+[`@OrgRoles` / `@OrgScope`](../../src/common/decorators/org-roles.decorator.ts).
+
+## Roles
+
+| Role         | Intended for                                  |
+| ------------ | --------------------------------------------- |
+| `owner`      | Full control, including deleting the org      |
+| `admin`      | Manage members and org settings               |
+| `instructor` | Teach within the org; read the member list    |
+| `member`     | Belong to the org; read the member list       |
+
+A membership is a row in `organization_members` pairing a `userId` with an
+`organizationId` and one of these roles. The schema constrains `role` to the
+enum, so a membership can never carry a value the guard would have to guess at.
+
+## How enforcement works
+
+A handler declares the roles it accepts and where the organization is found:
+
+```ts
+@Patch(':id')
+@UseGuards(JwtAuthGuard, OrganizationRolesGuard)
+@OrgScope({ source: 'param', key: 'id' })
+@OrgRoles(OrganizationRole.OWNER, OrganizationRole.ADMIN)
+update(@Param('id') id: string, @Body() dto: UpdateOrganizationDto) { … }
+```
+
+`@OrgScope.source` may be:
+
+| Source            | Resolution                                                        |
+| ----------------- | ----------------------------------------------------------------- |
+| `param`           | Read the organization id from a route parameter                   |
+| `body`            | Read it from the request body                                     |
+| `query`           | Read it from the query string                                     |
+| `membershipParam` | The parameter is a membership id; scope to *its* `organizationId` |
+
+`membershipParam` is what stops the obvious cross-tenant attack: without it, a
+route like `PATCH /organization-members/:id` would let the owner of org B edit a
+membership belonging to org A simply by knowing its id.
+
+The guard then looks up the caller's membership **in that specific
+organization**. Holding `owner` in another organization grants nothing. Every
+guarded route fails closed:
+
+- no `@OrgScope` on a guarded handler → 500 (misconfiguration, not a pass)
+- unauthenticated → 401
+- organization not resolvable → 403
+- no membership in that organization → 403
+- membership whose role is not listed → 403
+
+On success the resolved membership is attached to the request and readable via
+`@OrgMembership()`.
+
+## Route matrix
+
+### `/organizations`
+
+| Route                | Required                                    |
+| -------------------- | ------------------------------------------- |
+| `GET /`              | public                                      |
+| `GET /:id`           | public                                      |
+| `POST /`             | any authenticated user; creator becomes `owner` |
+| `PATCH /:id`         | org `owner` or `admin`                      |
+| `DELETE /:id`        | org `owner`                                 |
+
+### `/organization-members`
+
+| Route                          | Required                                        |
+| ------------------------------ | ----------------------------------------------- |
+| `GET /organization/:orgId`     | any member of that organization                 |
+| `GET /user/:userId`            | yourself only (platform `admin` may query any)  |
+| `GET /:id`                     | any member of the membership's organization     |
+| `POST /`                       | org `owner` or `admin` of the target org        |
+| `PATCH /:id`                   | org `owner` or `admin` of the membership's org  |
+| `DELETE /:id`                  | org `owner` or `admin` of the membership's org  |
+
+### Breaking changes
+
+- `POST /organizations` previously required the platform `admin` role. It is now
+  open to any authenticated user, who becomes the organization's `owner`. This
+  is what gives every later org-scoped check a principal to match; without it,
+  only platform admins could ever create an organization and no one would hold
+  an org role.
+- `PATCH`/`DELETE /organizations/:id` and all `/organization-members` mutations
+  previously required the platform `admin` role. They now require an
+  organization role. Platform admins retain access through the break-glass path
+  below, so existing admin tooling keeps working.
+- `GET /organization-members/user/:userId` previously let any authenticated user
+  enumerate anyone's memberships. It is now restricted to the caller's own id.
+- `GET /organization-members/organization/:orgId` and `GET /:id` previously
+  needed only authentication. They now require membership in that organization.
+- `role` is validated against the enum. Requests sending an arbitrary role
+  string now get 400 instead of persisting an unrecognised value.
+
+## Ownership rules
+
+Enforced in `OrganizationMemberService` on top of the guard:
+
+- Only an `owner` may grant or revoke the `owner` role. An org `admin` cannot
+  promote themselves.
+- Only an `owner` may remove another `owner`.
+- The last remaining `owner` cannot be demoted or removed, so an organization is
+  never left without an administrator.
+
+## Platform admin break-glass
+
+A platform `admin` with no membership may act on any organization, so support
+staff can administer any tenant. The path is deliberately narrow and visible:
+
+- It does **not** extend to `moderator` or any other global role.
+- When an admin *does* hold a real membership, that membership's role is used
+  instead of the bypass.
+- The resolved membership carries `viaPlatformAdmin: true`, and the resulting
+  mutation is recorded in the audit trail (see
+  [audit-logging.md](./audit-logging.md)).
+
+## Auditing
+
+Organization mutations are audited: `organization.created`,
+`organization.updated`, `organization.deleted`, `organization_member.added`,
+`organization_member.role_changed`, `organization_member.removed`.
+
+Deleting an organization also deletes its memberships, so a recreated id cannot
+inherit stale grants.
+
+## Tests
+
+- `src/common/guards/organization-roles.guard.spec.ts` — 17 cases including
+  cross-organization denial through `param`, `body` and `membershipParam`
+  scopes, fail-closed misconfiguration, and the limits of the admin bypass
+- `src/organization-member/organization-member.service.spec.ts` — ownership
+  transfer rules, last-owner protection, membership enumeration
+- `src/common/enums/organization-role.enum.spec.ts` — role hierarchy

--- a/docs/security/uploads.md
+++ b/docs/security/uploads.md
@@ -1,0 +1,156 @@
+# Worker uploads: hardening, quarantine and malware scanning
+
+Covers the previously public `POST /worker/upload` endpoint
+([`src/worker`](../../src/worker)).
+
+## What changed
+
+**Before:** the controller was `@Public()`, wrote caller-influenced files
+straight to `uploads/worker` via `diskStorage`, trusted the declared
+`Content-Type`, and returned the stored filename immediately. There was no
+quarantine, no scanning and no quota.
+
+**After:** uploads require authentication, are buffered in memory, validated on
+MIME *and* magic bytes, stored under a generated name outside any served tree,
+scanned, and only then made readable.
+
+## Request lifecycle
+
+```
+POST /worker/upload
+  │
+  ├─ JwtAuthGuard + RolesGuard        admin | moderator | tutor only
+  ├─ multer memoryStorage             10 MiB hard cap, 1 file, 10 fields
+  ├─ MIME pre-filter                  application/pdf, image/png, image/jpeg
+  ├─ size check                       UPLOAD_MAX_FILE_BYTES
+  ├─ magic byte validation            MIME + extension + signature must agree
+  ├─ quota check                      per-user bytes and file count
+  ├─ write to <root>/quarantine/      random UUID name, mode 0600
+  │                                   → audit: file_upload.quarantined
+  ├─ malware scan
+  │    ├─ clean    → move to <root>/clean/   status "clean"
+  │    ├─ infected → delete (or move to <root>/infected/) status "infected"
+  │    └─ error    → stays quarantined       status "error"
+  │                                   → audit: file_upload.scanned
+  └─ response with status; downloadUrl only when status is "clean"
+```
+
+Nothing untrusted touches the filesystem until it has passed validation, and
+nothing leaves quarantine until a scan says so.
+
+## Endpoints
+
+| Method   | Path                        | Notes                                                     |
+| -------- | --------------------------- | --------------------------------------------------------- |
+| `POST`   | `/worker/upload`            | Authenticated. Returns the upload record and its status.  |
+| `GET`    | `/worker/files`             | Your uploads and their scan status.                       |
+| `GET`    | `/worker/files/:id`         | Metadata for one upload. Owner or platform admin.         |
+| `GET`    | `/worker/files/:id/content` | Bytes. **409** unless the status is `clean`.              |
+| `DELETE` | `/worker/files/:id`         | Deletes the record and the stored bytes.                  |
+
+All require a bearer token and one of `admin`, `moderator`, `tutor`.
+
+### Breaking changes
+
+- The endpoint is **no longer public** — unauthenticated callers get 401, and
+  authenticated callers outside the three roles get 403.
+- The response no longer contains a `filename` field. It returns `id`, `status`,
+  `sha256`, `scan` and a `downloadUrl` that is `null` until the file is
+  released. Clients must poll or re-read `GET /worker/files/:id` rather than
+  assuming the upload is immediately usable.
+- Uploads are written under `UPLOAD_STORAGE_ROOT` (default `var/uploads`), not
+  `uploads/worker`.
+
+### Status values
+
+| Status     | Meaning                                     | Readable |
+| ---------- | ------------------------------------------- | -------- |
+| `pending`  | Accepted, quarantined, not yet scanned      | no       |
+| `scanning` | Scan in flight                              | no       |
+| `clean`    | Scanned clean and released                  | **yes**  |
+| `infected` | Detection; bytes deleted or quarantined     | no       |
+| `error`    | Scanner gave no verdict; stays quarantined  | no       |
+
+`error` is deliberately unreadable — the scanner fails closed, so an unreachable
+clamd never looks like a pass.
+
+## Validation
+
+An upload is accepted only when the declared MIME type, the filename extension
+and the leading magic bytes all agree:
+
+| MIME              | Extensions      | Signature                    |
+| ----------------- | --------------- | ---------------------------- |
+| `application/pdf` | `.pdf`          | `%PDF-`                      |
+| `image/png`       | `.png`          | `89 50 4E 47 0D 0A 1A 0A`    |
+| `image/jpeg`      | `.jpg`, `.jpeg` | `FF D8 FF`                   |
+
+A PE executable named `invoice.pdf` and sent as `application/pdf` is rejected,
+because its bytes start with `MZ`. Rejections are audited as
+`file_upload.rejected` with outcome `denied`.
+
+## Storage
+
+- The root defaults to `var/uploads`, outside any directory the application
+  serves, with three areas: `quarantine/`, `clean/` and `infected/`.
+- Storage names are `crypto.randomUUID()` plus a validated extension. The
+  caller's filename never influences a path; it is sanitized (basename only,
+  control characters stripped, leading dots removed, capped at 128 characters)
+  and kept as display metadata.
+- Files are written mode `0600` inside directories created `0700`, with
+  `flag: 'wx'` so an existing file is never overwritten.
+- `resolveWithin` rejects any key that resolves outside its area — a backstop
+  against a future caller passing a user-supplied key.
+- Downloads are always served `Content-Disposition: attachment` with
+  `X-Content-Type-Options: nosniff`, so uploaded content is never rendered
+  inline on the API origin.
+
+## Malware scanning
+
+Two backends, selected by `MALWARE_SCAN_PROVIDER`:
+
+- **`builtin`** (default) — detects the EICAR test string plus active content
+  smuggled into documents and images: PDF `/OpenAction` + `/JavaScript`,
+  embedded `/JS`, `/Launch` actions, `<script>` tags, `<?php` tags and
+  shebangs. No external dependency, so it works in CI and locally. It is a
+  defence-in-depth layer, **not** a replacement for a real engine.
+- **`clamav`** — streams the buffer to a clamd daemon over TCP using the
+  INSTREAM protocol. Recommended for production.
+
+Use the EICAR test string to exercise the quarantine path end to end without
+handling a real sample.
+
+## Configuration
+
+| Variable                  | Default        | Purpose                                          |
+| ------------------------- | -------------- | ------------------------------------------------ |
+| `UPLOAD_STORAGE_ROOT`     | `var/uploads`  | Storage root; keep outside any served directory  |
+| `UPLOAD_MAX_FILE_BYTES`   | `5242880`      | Max size of a single upload                      |
+| `UPLOAD_QUOTA_MAX_BYTES`  | `104857600`    | Max total stored bytes per user                  |
+| `UPLOAD_QUOTA_MAX_FILES`  | `20`           | Max uploads per user per window                  |
+| `UPLOAD_QUOTA_WINDOW_MS`  | `86400000`     | Rolling window for the file-count quota          |
+| `UPLOAD_RETAIN_INFECTED`  | `false`        | Keep detections under `infected/` instead of deleting |
+| `MALWARE_SCAN_PROVIDER`   | `builtin`      | `builtin` or `clamav`                            |
+| `MALWARE_SCAN_HOST`       | `127.0.0.1`    | clamd host                                       |
+| `MALWARE_SCAN_PORT`       | `3310`         | clamd port                                       |
+| `MALWARE_SCAN_TIMEOUT_MS` | `30000`        | Scan timeout; a timeout yields `error`, not `clean` |
+
+## Deployment notes
+
+- Add `UPLOAD_STORAGE_ROOT` to your volume mounts — uploads are not in the
+  application directory. `var/` is git-ignored.
+- Enable `clamav` in production and keep its definitions current.
+- Scanning currently runs inline within the request. The lifecycle is modelled
+  explicitly (`pending` → `scanning` → verdict), so moving the scan to a queue
+  later needs no API change.
+
+## Tests
+
+- `src/worker/worker.service.spec.ts` — lifecycle, quotas, release/quarantine,
+  download refusal per status, ownership, scan auditing
+- `src/worker/file-validation.spec.ts` — magic bytes, content-type confusion,
+  filename sanitization and traversal
+- `src/worker/file-storage.service.spec.ts` — quarantine-first writes, generated
+  names, permissions, area escape refusal
+- `src/worker/malware-scanner.service.spec.ts` — EICAR, heuristics, fail-closed
+  behaviour when clamd is unreachable

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -1,6 +1,15 @@
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ParseObjectIdPipe } from '../common/pipes/parse-object-id.pipe';
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { AdminAuthService } from './admin-auth.service';
 import { CreateAdminAuthDto } from './dto/create-admin-auth.dto';
 import { UpdateAdminAuthDto } from './dto/update-admin-auth.dto';
@@ -8,6 +17,8 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { AuditActor } from '../common/audit/audit-context';
+import type { AuditContext } from '../common/audit/audit-context';
 
 @ApiBearerAuth('access-token')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -29,19 +40,29 @@ export class AdminAuthController {
 
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Post()
-  create(@Body() payload: CreateAdminAuthDto) {
-    return this.service.create(payload);
+  create(
+    @Body() payload: CreateAdminAuthDto,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.create(payload, audit);
   }
 
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
   @Patch(':id')
-  update(@Param('id', new ParseObjectIdPipe()) id: string, @Body() payload: UpdateAdminAuthDto) {
-    return this.service.update(id, payload);
+  update(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @Body() payload: UpdateAdminAuthDto,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.update(id, payload, audit);
   }
 
   @Roles(Role.ADMIN)
   @Delete(':id')
-  remove(@Param('id', new ParseObjectIdPipe()) id: string) {
-    return this.service.remove(id);
+  remove(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.remove(id, audit);
   }
 }

--- a/src/admin-auth/admin-auth.service.spec.ts
+++ b/src/admin-auth/admin-auth.service.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { AdminAuthService } from './admin-auth.service';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import { AuditContext } from '../common/audit/audit-context';
+import { REDACTED } from '../common/audit/audit-redaction';
+
+const audit: AuditContext = {
+  actorId: 'admin-1',
+  actorEmail: 'admin@chainverse.io',
+  actorRole: 'admin',
+  requestId: 'req-77',
+  ip: '10.0.0.1',
+  userAgent: 'jest',
+};
+
+const auditService = { record: jest.fn().mockResolvedValue(null) };
+const entryFor = (action: AuditAction) =>
+  auditService.record.mock.calls
+    .map(([entry]) => entry)
+    .find((entry) => entry.action === action);
+
+describe('AdminAuthService account administration auditing', () => {
+  let service: AdminAuthService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminAuthService,
+        { provide: AuditService, useValue: auditService },
+      ],
+    }).compile();
+
+    service = module.get(AdminAuthService);
+  });
+
+  it('audits account creation with the actor and request ID', async () => {
+    const created: any = await service.create({ name: 'ops' } as never, audit);
+
+    const entry = entryFor(AuditAction.ADMIN_ACCOUNT_CREATED);
+    expect(entry).toBeDefined();
+    expect(entry.context).toBe(audit);
+    expect(entry.target).toEqual({
+      type: 'admin_account',
+      id: created.id,
+    });
+    expect(entry.before).toBeNull();
+    expect(entry.after).toEqual(expect.objectContaining({ name: 'ops' }));
+  });
+
+  it('audits an update with both before and after state', async () => {
+    const created: any = await service.create(
+      { name: 'ops', tier: 'one' } as never,
+      audit,
+    );
+    auditService.record.mockClear();
+
+    await service.update(created.id, { tier: 'two' } as never, audit);
+
+    const entry = entryFor(AuditAction.ADMIN_ACCOUNT_UPDATED);
+    expect(entry.before).toEqual(expect.objectContaining({ tier: 'one' }));
+    expect(entry.after).toEqual(expect.objectContaining({ tier: 'two' }));
+  });
+
+  it('redacts credentials in the audited snapshots', async () => {
+    const created: any = await service.create(
+      { name: 'ops', password: 'super-secret' } as never,
+      audit,
+    );
+
+    const entry = entryFor(AuditAction.ADMIN_ACCOUNT_CREATED);
+    expect(entry.after.password).toBe(REDACTED);
+    expect(JSON.stringify(entry)).not.toContain('super-secret');
+    expect(created.password).toBe('super-secret');
+  });
+
+  it('audits deletion with the prior state and a null after', async () => {
+    const created: any = await service.create({ name: 'ops' } as never, audit);
+    auditService.record.mockClear();
+
+    await service.remove(created.id, audit);
+
+    const entry = entryFor(AuditAction.ADMIN_ACCOUNT_DELETED);
+    expect(entry.before).toEqual(expect.objectContaining({ name: 'ops' }));
+    expect(entry.after).toBeNull();
+  });
+
+  it('does not audit a deletion that never happened', async () => {
+    await expect(service.remove('missing', audit)).rejects.toThrow(
+      NotFoundException,
+    );
+
+    expect(entryFor(AuditAction.ADMIN_ACCOUNT_DELETED)).toBeUndefined();
+  });
+
+  it('falls back to a system actor when no HTTP context is supplied', async () => {
+    await service.create({ name: 'seeded' } as never);
+
+    const entry = entryFor(AuditAction.ADMIN_ACCOUNT_CREATED);
+    expect(entry.context.actorId).toBe('system');
+  });
+});

--- a/src/admin-auth/admin-auth.service.ts
+++ b/src/admin-auth/admin-auth.service.ts
@@ -1,10 +1,21 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateAdminAuthDto } from './dto/create-admin-auth.dto';
 import { UpdateAdminAuthDto } from './dto/update-admin-auth.dto';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import {
+  AuditContext,
+  systemAuditContext,
+} from '../common/audit/audit-context';
+import { redactMetadata } from '../common/audit/audit-redaction';
+
+const TARGET_TYPE = 'admin_account';
 
 @Injectable()
 export class AdminAuthService {
   private readonly items: Array<{ id: string } & CreateAdminAuthDto> = [];
+
+  constructor(private readonly auditService: AuditService) {}
 
   findAll() {
     return this.items;
@@ -18,24 +29,53 @@ export class AdminAuthService {
     return item;
   }
 
-  create(payload: CreateAdminAuthDto) {
+  async create(payload: CreateAdminAuthDto, audit?: AuditContext) {
     const created = { id: crypto.randomUUID(), ...payload };
     this.items.push(created);
+
+    await this.auditService.record({
+      action: AuditAction.ADMIN_ACCOUNT_CREATED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id: created.id },
+      before: null,
+      after: redactMetadata({ ...created }),
+    });
+
     return created;
   }
 
-  update(id: string, payload: UpdateAdminAuthDto) {
+  async update(id: string, payload: UpdateAdminAuthDto, audit?: AuditContext) {
     const item = this.findOne(id);
+    const before = redactMetadata({ ...item });
+
     Object.assign(item, payload);
+
+    await this.auditService.record({
+      action: AuditAction.ADMIN_ACCOUNT_UPDATED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before,
+      after: redactMetadata({ ...item }),
+    });
+
     return item;
   }
 
-  remove(id: string) {
+  async remove(id: string, audit?: AuditContext) {
     const index = this.items.findIndex((entry) => entry.id === id);
     if (index === -1) {
       throw new NotFoundException('AdminAuth item not found');
     }
-    this.items.splice(index, 1);
+    const [removed] = this.items.splice(index, 1);
+
+    await this.auditService.record({
+      action: AuditAction.ADMIN_ACCOUNT_DELETED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before: redactMetadata({ ...removed }),
+      after: null,
+    });
+
     return { id, deleted: true };
   }
 }

--- a/src/admin-course/admin-course.audit.spec.ts
+++ b/src/admin-course/admin-course.audit.spec.ts
@@ -1,0 +1,235 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { getModelToken } from '@nestjs/mongoose';
+import { AdminCourseService } from './admin-course.service';
+import { Course } from './schemas/course.schema';
+import { Tutor } from '../tutor/schemas/tutor.schema';
+import { EmailService } from '../email/email.service';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import { AuditContext } from '../common/audit/audit-context';
+
+const audit: AuditContext = {
+  actorId: 'admin-7',
+  actorEmail: 'admin@chainverse.io',
+  actorRole: 'admin',
+  requestId: 'req-course-1',
+  ip: '10.0.0.3',
+  userAgent: 'jest',
+};
+
+const auditService = { record: jest.fn().mockResolvedValue(null) };
+const entryFor = (action: AuditAction) =>
+  auditService.record.mock.calls
+    .map(([entry]) => entry)
+    .find((entry) => entry.action === action);
+
+const courseDoc = (over: Record<string, unknown> = {}) => ({
+  id: 'course-1',
+  title: 'Solidity 101',
+  category: 'blockchain',
+  price: 100,
+  status: 'pending',
+  // updateTutorStats casts this to an ObjectId, so it must be a valid one.
+  tutorId: '507f1f77bcf86cd799439011',
+  tutorEmail: 'tutor@chainverse.io',
+  totalEnrollments: 0,
+  approvedAt: undefined,
+  publishedAt: undefined,
+  rejectionReason: undefined,
+  save: jest.fn().mockResolvedValue(undefined),
+  toObject() {
+    const { toObject, save, ...rest } = this;
+    return rest;
+  },
+  ...over,
+});
+
+const exec = <T>(value: T) => ({ exec: jest.fn().mockResolvedValue(value) });
+
+const mockCourseModel: any = jest.fn();
+const mockTutorModel: any = jest.fn();
+
+describe('AdminCourseService privileged action auditing', () => {
+  let service: AdminCourseService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockCourseModel.findById = jest.fn();
+    mockCourseModel.findByIdAndUpdate = jest.fn().mockReturnValue(exec(null));
+    mockTutorModel.findByIdAndUpdate = jest.fn().mockReturnValue(exec(null));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminCourseService,
+        { provide: getModelToken(Course.name), useValue: mockCourseModel },
+        { provide: getModelToken(Tutor.name), useValue: mockTutorModel },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        {
+          provide: EmailService,
+          useValue: { send: jest.fn().mockResolvedValue(undefined) },
+        },
+        { provide: AuditService, useValue: auditService },
+      ],
+    }).compile();
+
+    service = module.get(AdminCourseService);
+  });
+
+  describe('review', () => {
+    it('audits an approval with the status transition and the actor', async () => {
+      mockCourseModel.findById.mockReturnValue(exec(courseDoc()));
+
+      await service.review(
+        'course-1',
+        { decision: 'approved' } as never,
+        'admin-7',
+        audit,
+      );
+
+      const entry = entryFor(AuditAction.COURSE_REVIEWED);
+      expect(entry.context).toBe(audit);
+      expect(entry.target).toEqual({ type: 'course', id: 'course-1' });
+      expect(entry.before).toEqual(
+        expect.objectContaining({ status: 'pending' }),
+      );
+      expect(entry.after).toEqual(
+        expect.objectContaining({ status: 'approved' }),
+      );
+    });
+
+    it('records the rejection reason', async () => {
+      mockCourseModel.findById.mockReturnValue(exec(courseDoc()));
+
+      await service.review(
+        'course-1',
+        { decision: 'rejected', reason: 'thin curriculum' } as never,
+        'admin-7',
+        audit,
+      );
+
+      const entry = entryFor(AuditAction.COURSE_REVIEWED);
+      expect(entry.reason).toBe('thin curriculum');
+      expect(entry.after).toEqual(
+        expect.objectContaining({ status: 'rejected' }),
+      );
+    });
+
+    it('does not audit a review the service refuses', async () => {
+      mockCourseModel.findById.mockReturnValue(
+        exec(courseDoc({ status: 'published' })),
+      );
+
+      await expect(
+        service.review(
+          'course-1',
+          { decision: 'approved' } as never,
+          'admin-7',
+          audit,
+        ),
+      ).rejects.toThrow(/Only pending courses/);
+
+      expect(auditService.record).not.toHaveBeenCalled();
+    });
+
+    it('attributes the review to the admin even without an HTTP context', async () => {
+      mockCourseModel.findById.mockReturnValue(exec(courseDoc()));
+
+      await service.review(
+        'course-1',
+        { decision: 'approved' } as never,
+        'admin-7',
+      );
+
+      expect(entryFor(AuditAction.COURSE_REVIEWED).context.actorId).toBe(
+        'admin-7',
+      );
+    });
+  });
+
+  describe('publish and unpublish', () => {
+    it('audits an admin publish', async () => {
+      mockCourseModel.findById.mockReturnValue(
+        exec(courseDoc({ status: 'approved' })),
+      );
+
+      await service.publish('course-1', 'admin-7', true, audit);
+
+      const entry = entryFor(AuditAction.COURSE_PUBLISHED);
+      expect(entry.before).toEqual(
+        expect.objectContaining({ status: 'approved' }),
+      );
+      expect(entry.after).toEqual(
+        expect.objectContaining({ status: 'published' }),
+      );
+    });
+
+    it('audits an admin unpublish', async () => {
+      mockCourseModel.findById.mockReturnValue(
+        exec(courseDoc({ status: 'published' })),
+      );
+
+      await service.unpublish('course-1', 'admin-7', true, audit);
+
+      expect(entryFor(AuditAction.COURSE_UNPUBLISHED)).toBeDefined();
+    });
+
+    // Tutors acting on their own courses are ordinary authorship, not a
+    // privileged action, so they stay out of the audit trail.
+    it('does not audit a tutor publishing their own course', async () => {
+      mockCourseModel.findById.mockReturnValue(
+        exec(courseDoc({ status: 'approved' })),
+      );
+
+      await service.publish('course-1', '507f1f77bcf86cd799439011', false);
+
+      expect(auditService.record).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('audits an admin deletion with the reason', async () => {
+      mockCourseModel.findById.mockReturnValue(
+        exec(courseDoc({ status: 'published' })),
+      );
+
+      await service.delete('course-1', 'admin-7', true, 'DMCA takedown', audit);
+
+      const entry = entryFor(AuditAction.COURSE_DELETED);
+      expect(entry.reason).toBe('DMCA takedown');
+      expect(entry.after).toEqual(
+        expect.objectContaining({ deletedBy: 'admin:admin-7' }),
+      );
+    });
+
+    it('does not audit a tutor deleting their own course', async () => {
+      mockCourseModel.findById.mockReturnValue(exec(courseDoc()));
+
+      await service.delete('course-1', '507f1f77bcf86cd799439011', false);
+
+      expect(auditService.record).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('audits an admin update', async () => {
+      mockCourseModel.findById.mockReturnValue(exec(courseDoc()));
+
+      await service.update(
+        'course-1',
+        { title: 'Solidity 102' },
+        'admin-7',
+        true,
+        audit,
+      );
+
+      const entry = entryFor(AuditAction.COURSE_UPDATED);
+      expect(entry.before).toEqual(
+        expect.objectContaining({ title: 'Solidity 101' }),
+      );
+      expect(entry.after).toEqual(
+        expect.objectContaining({ title: 'Solidity 102' }),
+      );
+    });
+  });
+});

--- a/src/admin-course/admin-course.controller.ts
+++ b/src/admin-course/admin-course.controller.ts
@@ -10,6 +10,8 @@ import { RolesGuard } from '../common/guards/roles.guard';
 import { Roles } from '../common/decorators/roles.decorator';
 import { Role } from '../common/enums/role.enum';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { AuditActor } from '../common/audit/audit-context';
+import type { AuditContext } from '../common/audit/audit-context';
 
 @ApiBearerAuth('access-token')
 @ApiTags('Admin Courses')
@@ -50,20 +52,29 @@ export class AdminCourseController {
     @Param('id', new ParseObjectIdPipe()) id: string,
     @Body() dto: ReviewCourseDto,
     @CurrentUser('sub') adminId: string,
+    @AuditActor() audit: AuditContext,
   ) {
-    return this.adminCourseService.review(id, dto, adminId);
+    return this.adminCourseService.review(id, dto, adminId, audit);
   }
 
   @Patch(':id/publish')
   @ApiOperation({ summary: 'Publish a course' })
-  publish(@Param('id', new ParseObjectIdPipe()) id: string, @CurrentUser('sub') adminId: string) {
-    return this.adminCourseService.publish(id, adminId, true);
+  publish(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @CurrentUser('sub') adminId: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.adminCourseService.publish(id, adminId, true, audit);
   }
 
   @Patch(':id/unpublish')
   @ApiOperation({ summary: 'Unpublish a course' })
-  unpublish(@Param('id', new ParseObjectIdPipe()) id: string, @CurrentUser('sub') adminId: string) {
-    return this.adminCourseService.unpublish(id, adminId, true);
+  unpublish(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @CurrentUser('sub') adminId: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.adminCourseService.unpublish(id, adminId, true, audit);
   }
 
   @Patch(':id')
@@ -72,8 +83,9 @@ export class AdminCourseController {
     @Param('id', new ParseObjectIdPipe()) id: string,
     @Body() dto: UpdateCourseDto,
     @CurrentUser('sub') adminId: string,
+    @AuditActor() audit: AuditContext,
   ) {
-    return this.adminCourseService.update(id, dto, adminId, true);
+    return this.adminCourseService.update(id, dto, adminId, true, audit);
   }
 
   @Delete(':id')
@@ -82,9 +94,10 @@ export class AdminCourseController {
   delete(
     @Param('id', new ParseObjectIdPipe()) id: string,
     @CurrentUser('sub') adminId: string,
+    @AuditActor() audit: AuditContext,
     @Query('reason') reason?: string,
   ) {
-    return this.adminCourseService.delete(id, adminId, true, reason);
+    return this.adminCourseService.delete(id, adminId, true, reason, audit);
   }
 
   @Get(':id/enrollments')

--- a/src/admin-course/admin-course.service.ts
+++ b/src/admin-course/admin-course.service.ts
@@ -9,6 +9,26 @@ import { Course, CourseDocument } from './schemas/course.schema';
 import { Tutor, TutorDocument } from '../tutor/schemas/tutor.schema';
 import { DomainEvents } from '../events/event-names';
 import { EmailService } from '../email/email.service';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import { AuditContext, systemAuditContext } from '../common/audit/audit-context';
+import { snapshot } from '../common/audit/audit-redaction';
+
+/** Fields captured in course audit before/after snapshots. */
+const COURSE_AUDIT_FIELDS = [
+  'title',
+  'category',
+  'price',
+  'status',
+  'level',
+  'language',
+  'publishedAt',
+  'approvedAt',
+  'rejectionReason',
+  'deletedAt',
+  'deletedBy',
+  'deletionReason',
+] as const;
 
 @Injectable()
 export class AdminCourseService {
@@ -19,7 +39,29 @@ export class AdminCourseService {
     private readonly tutorModel: Model<TutorDocument>,
     private readonly eventEmitter: EventEmitter2,
     private readonly emailService: EmailService,
+    private readonly auditService: AuditService,
   ) {}
+
+  /**
+   * Records a privileged course mutation. Callers that have no HTTP context
+   * (background jobs, tests) fall back to a system actor.
+   */
+  private auditCourse(
+    action: AuditAction,
+    course: CourseDocument,
+    before: Record<string, unknown> | null,
+    audit: AuditContext | undefined,
+    reason?: string | null,
+  ): Promise<unknown> {
+    return this.auditService.record({
+      action,
+      context: audit ?? systemAuditContext(),
+      target: { type: 'course', id: course.id },
+      before,
+      after: snapshot(course, COURSE_AUDIT_FIELDS),
+      reason: reason ?? null,
+    });
+  }
 
   /**
    * Create a new course (for tutors)
@@ -118,8 +160,10 @@ export class AdminCourseService {
     dto: UpdateCourseDto,
     tutorId?: string,
     isAdmin: boolean = false,
+    audit?: AuditContext,
   ): Promise<CourseDocument> {
     const course = await this.findOne(id);
+    const before = snapshot(course, COURSE_AUDIT_FIELDS);
 
     // Ownership check - only tutor or admin can update
     if (!isAdmin && course.tutorId !== tutorId) {
@@ -153,6 +197,15 @@ export class AdminCourseService {
 
     Object.assign(course, dto);
     await course.save();
+
+    if (isAdmin) {
+      await this.auditCourse(
+        AuditAction.COURSE_UPDATED,
+        course,
+        before,
+        audit,
+      );
+    }
 
     return course;
   }
@@ -208,8 +261,10 @@ export class AdminCourseService {
     id: string,
     dto: ReviewCourseDto,
     adminId: string,
+    audit?: AuditContext,
   ): Promise<{ message: string; course: CourseDocument }> {
     const course = await this.findOne(id);
+    const before = snapshot(course, COURSE_AUDIT_FIELDS);
 
     if (course.status !== 'pending') {
       throw new BadRequestException('Only pending courses can be reviewed');
@@ -237,6 +292,14 @@ export class AdminCourseService {
 
     await course.save();
 
+    await this.auditCourse(
+      AuditAction.COURSE_REVIEWED,
+      course,
+      before,
+      audit ?? systemAuditContext('system', adminId),
+      dto.reason ?? null,
+    );
+
     this.eventEmitter.emit('course.reviewed', {
       courseId: course.id,
       tutorId: course.tutorId,
@@ -254,8 +317,10 @@ export class AdminCourseService {
     id: string,
     tutorId: string,
     isAdmin: boolean = false,
+    audit?: AuditContext,
   ): Promise<{ message: string; course: CourseDocument }> {
     const course = await this.findOne(id);
+    const before = snapshot(course, COURSE_AUDIT_FIELDS);
 
     // Only tutor or admin can publish
     if (!isAdmin && course.tutorId !== tutorId) {
@@ -271,6 +336,15 @@ export class AdminCourseService {
     course.status = 'published';
     course.publishedAt = new Date();
     await course.save();
+
+    if (isAdmin) {
+      await this.auditCourse(
+        AuditAction.COURSE_PUBLISHED,
+        course,
+        before,
+        audit,
+      );
+    }
 
     this.eventEmitter.emit('course.published', {
       courseId: course.id,
@@ -289,8 +363,10 @@ export class AdminCourseService {
     id: string,
     tutorId: string,
     isAdmin: boolean = false,
+    audit?: AuditContext,
   ): Promise<{ message: string; course: CourseDocument }> {
     const course = await this.findOne(id);
+    const before = snapshot(course, COURSE_AUDIT_FIELDS);
 
     // Only tutor or admin can unpublish
     if (!isAdmin && course.tutorId !== tutorId) {
@@ -305,6 +381,15 @@ export class AdminCourseService {
 
     course.status = 'unpublished';
     await course.save();
+
+    if (isAdmin) {
+      await this.auditCourse(
+        AuditAction.COURSE_UNPUBLISHED,
+        course,
+        before,
+        audit,
+      );
+    }
 
     this.eventEmitter.emit('course.unpublished', {
       courseId: course.id,
@@ -324,8 +409,10 @@ export class AdminCourseService {
     userId: string,
     isAdmin: boolean = false,
     reason?: string,
+    audit?: AuditContext,
   ): Promise<{ message: string }> {
     const course = await this.findOne(id);
+    const before = snapshot(course, COURSE_AUDIT_FIELDS);
 
     // Only tutor or admin can delete
     if (!isAdmin && course.tutorId !== userId) {
@@ -343,6 +430,16 @@ export class AdminCourseService {
     course.deletedBy = isAdmin ? `admin:${userId}` : `tutor:${userId}`;
     course.deletionReason = reason || 'User requested deletion';
     await course.save();
+
+    if (isAdmin) {
+      await this.auditCourse(
+        AuditAction.COURSE_DELETED,
+        course,
+        before,
+        audit,
+        course.deletionReason,
+      );
+    }
 
     // Update tutor stats
     await this.updateTutorStats(course.tutorId, -1);

--- a/src/admin-financial-aid-management/admin-financial-aid-management.controller.ts
+++ b/src/admin-financial-aid-management/admin-financial-aid-management.controller.ts
@@ -1,6 +1,15 @@
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ParseObjectIdPipe } from '../common/pipes/parse-object-id.pipe';
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { AdminFinancialAidManagementService } from './admin-financial-aid-management.service';
 import { CreateAdminFinancialAidManagementDto } from './dto/create-admin-financial-aid-management.dto';
 import { UpdateAdminFinancialAidManagementDto } from './dto/update-admin-financial-aid-management.dto';
@@ -8,6 +17,8 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { AuditActor } from '../common/audit/audit-context';
+import type { AuditContext } from '../common/audit/audit-context';
 
 @ApiBearerAuth('access-token')
 @Controller('admin/financial-aid')
@@ -29,8 +40,11 @@ export class AdminFinancialAidManagementController {
 
   @Post()
   @Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
-  create(@Body() payload: CreateAdminFinancialAidManagementDto) {
-    return this.service.create(payload);
+  create(
+    @Body() payload: CreateAdminFinancialAidManagementDto,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.create(payload, audit);
   }
 
   @Patch(':id')
@@ -39,15 +53,18 @@ export class AdminFinancialAidManagementController {
   update(
     @Param('id', new ParseObjectIdPipe()) id: string,
     @Body() payload: UpdateAdminFinancialAidManagementDto,
+    @AuditActor() audit: AuditContext,
   ) {
-    return this.service.update(id, payload);
+    return this.service.update(id, payload, audit);
   }
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR)
-  remove(@Param('id', new ParseObjectIdPipe()) id: string) {
-    return this.service.remove(id);
+  remove(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.remove(id, audit);
   }
 }
-

--- a/src/admin-financial-aid-management/admin-financial-aid-management.service.ts
+++ b/src/admin-financial-aid-management/admin-financial-aid-management.service.ts
@@ -1,12 +1,23 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateAdminFinancialAidManagementDto } from './dto/create-admin-financial-aid-management.dto';
 import { UpdateAdminFinancialAidManagementDto } from './dto/update-admin-financial-aid-management.dto';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import {
+  AuditContext,
+  systemAuditContext,
+} from '../common/audit/audit-context';
+import { redactMetadata } from '../common/audit/audit-redaction';
+
+const TARGET_TYPE = 'financial_aid_decision';
 
 @Injectable()
 export class AdminFinancialAidManagementService {
   private readonly items: Array<
     { id: string } & CreateAdminFinancialAidManagementDto
   > = [];
+
+  constructor(private readonly auditService: AuditService) {}
 
   findAll() {
     return this.items;
@@ -20,24 +31,60 @@ export class AdminFinancialAidManagementService {
     return item;
   }
 
-  create(payload: CreateAdminFinancialAidManagementDto) {
+  async create(
+    payload: CreateAdminFinancialAidManagementDto,
+    audit?: AuditContext,
+  ) {
     const created = { id: crypto.randomUUID(), ...payload };
     this.items.push(created);
+
+    await this.auditService.record({
+      action: AuditAction.FINANCIAL_AID_CREATED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id: created.id },
+      before: null,
+      after: redactMetadata({ ...created }),
+    });
+
     return created;
   }
 
-  update(id: string, payload: UpdateAdminFinancialAidManagementDto) {
+  async update(
+    id: string,
+    payload: UpdateAdminFinancialAidManagementDto,
+    audit?: AuditContext,
+  ) {
     const item = this.findOne(id);
+    const before = redactMetadata({ ...item });
+
     Object.assign(item, payload);
+
+    await this.auditService.record({
+      action: AuditAction.FINANCIAL_AID_UPDATED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before,
+      after: redactMetadata({ ...item }),
+    });
+
     return item;
   }
 
-  remove(id: string) {
+  async remove(id: string, audit?: AuditContext) {
     const index = this.items.findIndex((entry) => entry.id === id);
     if (index === -1) {
       throw new NotFoundException('AdminFinancialAidManagement item not found');
     }
-    this.items.splice(index, 1);
+    const [removed] = this.items.splice(index, 1);
+
+    await this.auditService.record({
+      action: AuditAction.FINANCIAL_AID_DELETED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before: redactMetadata({ ...removed }),
+      after: null,
+    });
+
     return { id, deleted: true };
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import appConfig from './config/app.config';
 import { envValidationSchema } from './common/config/env.validation';
 import { AppService } from './app.service';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
+import { AuditModule } from './common/audit/audit.module';
 import { WorkerModule } from './worker/worker.module';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { MetricsModule } from './metrics/metrics.module';
@@ -120,6 +121,8 @@ import { VerificationModule } from './verification/verification.module';
       inject: [ConfigService],
     }),
     AppLoggerModule,
+    // Global: exports AuditService to every feature module.
+    AuditModule,
     WorkerModule,
     MetricsModule,
     TracingModule,

--- a/src/common/audit/audit-action.enum.ts
+++ b/src/common/audit/audit-action.enum.ts
@@ -1,0 +1,53 @@
+/**
+ * Canonical list of privileged actions that must leave an audit trail.
+ *
+ * Values are namespaced `<domain>.<verb>` so log consumers can filter by
+ * domain prefix without maintaining a second mapping.
+ */
+export enum AuditAction {
+  // Course review / moderation (src/admin-course)
+  COURSE_REVIEWED = 'course.reviewed',
+  COURSE_PUBLISHED = 'course.published',
+  COURSE_UNPUBLISHED = 'course.unpublished',
+  COURSE_UPDATED = 'course.updated',
+  COURSE_DELETED = 'course.deleted',
+
+  // Financial aid decisions (src/admin-financial-aid-management)
+  FINANCIAL_AID_CREATED = 'financial_aid.created',
+  FINANCIAL_AID_UPDATED = 'financial_aid.updated',
+  FINANCIAL_AID_DELETED = 'financial_aid.deleted',
+
+  // Account administration (src/admin-auth)
+  ADMIN_ACCOUNT_CREATED = 'admin_account.created',
+  ADMIN_ACCOUNT_UPDATED = 'admin_account.updated',
+  ADMIN_ACCOUNT_DELETED = 'admin_account.deleted',
+
+  // Abuse report moderation (src/report-abuse)
+  ABUSE_REPORT_UPDATED = 'abuse_report.updated',
+  ABUSE_REPORT_DELETED = 'abuse_report.deleted',
+
+  // Organization administration (src/organization, src/organization-member)
+  ORGANIZATION_CREATED = 'organization.created',
+  ORGANIZATION_UPDATED = 'organization.updated',
+  ORGANIZATION_DELETED = 'organization.deleted',
+  ORGANIZATION_MEMBER_ADDED = 'organization_member.added',
+  ORGANIZATION_MEMBER_ROLE_CHANGED = 'organization_member.role_changed',
+  ORGANIZATION_MEMBER_REMOVED = 'organization_member.removed',
+
+  // Upload lifecycle (src/worker)
+  FILE_UPLOAD_QUARANTINED = 'file_upload.quarantined',
+  FILE_UPLOAD_SCANNED = 'file_upload.scanned',
+  FILE_UPLOAD_RELEASED = 'file_upload.released',
+  FILE_UPLOAD_REJECTED = 'file_upload.rejected',
+  FILE_UPLOAD_DELETED = 'file_upload.deleted',
+}
+
+/**
+ * Result of the audited attempt. `DENIED` records authorization failures,
+ * which are as interesting to a reviewer as successful mutations.
+ */
+export enum AuditOutcome {
+  SUCCESS = 'success',
+  FAILURE = 'failure',
+  DENIED = 'denied',
+}

--- a/src/common/audit/audit-context.spec.ts
+++ b/src/common/audit/audit-context.spec.ts
@@ -1,0 +1,71 @@
+import { resolveAuditContext, systemAuditContext } from './audit-context';
+
+describe('resolveAuditContext', () => {
+  it('reads identity, correlation ID and client details from the request', () => {
+    const context = resolveAuditContext({
+      user: { sub: 'admin-1', email: 'admin@chainverse.io', role: 'admin' },
+      headers: { 'x-request-id': 'req-42', 'user-agent': 'curl/8' },
+      ip: '203.0.113.9',
+    });
+
+    expect(context).toEqual({
+      actorId: 'admin-1',
+      actorEmail: 'admin@chainverse.io',
+      actorRole: 'admin',
+      requestId: 'req-42',
+      ip: '203.0.113.9',
+      userAgent: 'curl/8',
+    });
+  });
+
+  it('falls back to user.id when sub is absent', () => {
+    const context = resolveAuditContext({ user: { id: 'legacy-id' } });
+
+    expect(context.actorId).toBe('legacy-id');
+  });
+
+  it('records an unauthenticated attempt as anonymous rather than throwing', () => {
+    const context = resolveAuditContext({});
+
+    expect(context.actorId).toBe('anonymous');
+    expect(context.actorEmail).toBeNull();
+    expect(context.actorRole).toBeNull();
+    expect(context.requestId).toBe('unknown');
+  });
+
+  it('falls back to the socket address when ip is unset', () => {
+    const context = resolveAuditContext({
+      socket: { remoteAddress: '198.51.100.7' },
+    });
+
+    expect(context.ip).toBe('198.51.100.7');
+  });
+
+  it('ignores non-string identity claims', () => {
+    const context = resolveAuditContext({
+      user: { sub: 12345 as unknown as string },
+    });
+
+    expect(context.actorId).toBe('anonymous');
+  });
+});
+
+describe('systemAuditContext', () => {
+  it('marks non-HTTP callers as the system actor', () => {
+    expect(systemAuditContext()).toEqual({
+      actorId: 'system',
+      actorEmail: null,
+      actorRole: 'system',
+      requestId: 'system',
+      ip: null,
+      userAgent: null,
+    });
+  });
+
+  it('accepts an explicit request id and actor', () => {
+    const context = systemAuditContext('job-7', 'reconciler');
+
+    expect(context.requestId).toBe('job-7');
+    expect(context.actorId).toBe('reconciler');
+  });
+});

--- a/src/common/audit/audit-context.ts
+++ b/src/common/audit/audit-context.ts
@@ -1,0 +1,70 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/**
+ * Everything about the caller that an audit entry needs, resolved once per
+ * request from the authenticated principal and the correlation headers.
+ */
+export interface AuditContext {
+  actorId: string;
+  actorEmail: string | null;
+  actorRole: string | null;
+  requestId: string;
+  ip: string | null;
+  userAgent: string | null;
+}
+
+interface AuditableRequest {
+  user?: Record<string, unknown>;
+  headers?: Record<string, unknown>;
+  ip?: string;
+  socket?: { remoteAddress?: string };
+}
+
+const asString = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null;
+
+/**
+ * Builds an {@link AuditContext} from an HTTP request. Missing identity is
+ * represented as `anonymous` rather than throwing — an unauthenticated
+ * privileged attempt is exactly the kind of event worth recording.
+ */
+export function resolveAuditContext(request: AuditableRequest): AuditContext {
+  const user = request?.user ?? {};
+  const headers = request?.headers ?? {};
+
+  return {
+    actorId: asString(user['sub']) ?? asString(user['id']) ?? 'anonymous',
+    actorEmail: asString(user['email']),
+    actorRole: asString(user['role']),
+    requestId: asString(headers['x-request-id']) ?? 'unknown',
+    ip: asString(request?.ip) ?? asString(request?.socket?.remoteAddress),
+    userAgent: asString(headers['user-agent']),
+  };
+}
+
+/**
+ * Injects the resolved {@link AuditContext} into a controller handler:
+ *
+ * ```ts
+ * update(@Param('id') id: string, @AuditActor() audit: AuditContext) { … }
+ * ```
+ */
+export const AuditActor = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuditContext =>
+    resolveAuditContext(ctx.switchToHttp().getRequest()),
+);
+
+/** Context used by background jobs and other non-HTTP callers. */
+export function systemAuditContext(
+  requestId = 'system',
+  actorId = 'system',
+): AuditContext {
+  return {
+    actorId,
+    actorEmail: null,
+    actorRole: 'system',
+    requestId,
+    ip: null,
+    userAgent: null,
+  };
+}

--- a/src/common/audit/audit-redaction.spec.ts
+++ b/src/common/audit/audit-redaction.spec.ts
@@ -1,0 +1,152 @@
+import {
+  isSensitiveKey,
+  maskEmail,
+  redactMetadata,
+  snapshot,
+  REDACTED,
+} from './audit-redaction';
+
+describe('audit redaction', () => {
+  describe('isSensitiveKey', () => {
+    it.each([
+      'password',
+      'Password',
+      'newPassword',
+      'refreshToken',
+      'API_KEY',
+      'api-key',
+      'authorization',
+      'card_number',
+      'ssn',
+      'mnemonic',
+    ])('flags %s as sensitive', (key) => {
+      expect(isSensitiveKey(key)).toBe(true);
+    });
+
+    it.each(['status', 'title', 'decision', 'organizationId', 'role'])(
+      'leaves %s alone',
+      (key) => {
+        expect(isSensitiveKey(key)).toBe(false);
+      },
+    );
+  });
+
+  describe('maskEmail', () => {
+    it('keeps the domain and first character only', () => {
+      expect(maskEmail('ada@example.com')).toBe('a**@example.com');
+    });
+
+    it('leaves non-addresses untouched', () => {
+      expect(maskEmail('not-an-email')).toBe('not-an-email');
+    });
+  });
+
+  describe('redactMetadata', () => {
+    it('replaces sensitive values but keeps the key present', () => {
+      const result = redactMetadata({
+        email: 'admin@chainverse.io',
+        password: 'hunter2',
+        refreshToken: 'eyJhbGciOi...',
+        status: 'approved',
+      }) as Record<string, unknown>;
+
+      expect(result.password).toBe(REDACTED);
+      expect(result.refreshToken).toBe(REDACTED);
+      expect(result.status).toBe('approved');
+      expect(result.email).toBe('a****@chainverse.io');
+    });
+
+    it('redacts nested sensitive values', () => {
+      const result = redactMetadata({
+        actor: { id: 'u1', credentials: { secret: 'abc' } },
+      }) as Record<string, any>;
+
+      expect(result.actor.id).toBe('u1');
+      expect(result.actor.credentials).toBe(REDACTED);
+    });
+
+    it('truncates oversized strings', () => {
+      const result = redactMetadata(
+        { note: 'a'.repeat(1000) },
+        { maxStringLength: 10 },
+      ) as Record<string, string>;
+
+      expect(result.note.startsWith('aaaaaaaaaa')).toBe(true);
+      expect(result.note).toContain('truncated');
+      expect(result.note.length).toBeLessThan(1000);
+    });
+
+    it('caps array length and reports how many were dropped', () => {
+      const result = redactMetadata([1, 2, 3, 4, 5], {
+        maxArrayLength: 2,
+      }) as unknown[];
+
+      expect(result).toEqual([1, 2, '[+3 more]']);
+    });
+
+    it('collapses branches deeper than maxDepth', () => {
+      const deep = { a: { b: { c: { d: 'too far' } } } };
+      const result = redactMetadata(deep, { maxDepth: 2 }) as Record<
+        string,
+        any
+      >;
+
+      expect(result.a.b).toBe('[depth-limit]');
+    });
+
+    it('breaks cycles instead of overflowing the stack', () => {
+      const cyclic: Record<string, unknown> = { name: 'root' };
+      cyclic.self = cyclic;
+
+      const result = redactMetadata(cyclic) as Record<string, unknown>;
+
+      expect(result.name).toBe('root');
+      expect(result.self).toBe('[circular]');
+    });
+
+    it('serialises dates and buffers to storable primitives', () => {
+      const date = new Date('2026-01-01T00:00:00.000Z');
+      const result = redactMetadata({
+        at: date,
+        blob: Buffer.from('abc'),
+      }) as Record<string, unknown>;
+
+      expect(result.at).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.blob).toBe('[buffer:3]');
+    });
+
+    it('maps null and undefined to null', () => {
+      expect(redactMetadata(null)).toBeNull();
+      expect(redactMetadata(undefined)).toBeNull();
+    });
+  });
+
+  describe('snapshot', () => {
+    it('keeps only the requested fields and redacts them', () => {
+      const result = snapshot(
+        { status: 'pending', password: 'x', title: 'Course', extra: 'drop me' },
+        ['status', 'title', 'password'],
+      );
+
+      expect(result).toEqual({
+        status: 'pending',
+        title: 'Course',
+        password: REDACTED,
+      });
+    });
+
+    it('unwraps mongoose documents via toObject', () => {
+      const doc = {
+        toObject: () => ({ status: 'approved', title: 'Course' }),
+      };
+
+      expect(snapshot(doc as never, ['status'])).toEqual({
+        status: 'approved',
+      });
+    });
+
+    it('returns null for a missing source', () => {
+      expect(snapshot(null, ['status'])).toBeNull();
+    });
+  });
+});

--- a/src/common/audit/audit-redaction.ts
+++ b/src/common/audit/audit-redaction.ts
@@ -1,0 +1,181 @@
+/**
+ * Redaction helpers for audit metadata.
+ *
+ * Audit entries carry before/after snapshots of privileged mutations, so they
+ * are a prime target for credential and PII leakage. Everything written to the
+ * audit collection passes through {@link redactMetadata} first.
+ */
+
+/** Key names (case-insensitive substring match) whose values are never stored. */
+export const SENSITIVE_KEY_PATTERNS: readonly string[] = [
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'authorization',
+  'apikey',
+  'api_key',
+  'accesskey',
+  'privatekey',
+  'credential',
+  'sessionid',
+  'cookie',
+  'otp',
+  'pin',
+  'cvv',
+  'cardnumber',
+  'card_number',
+  'ssn',
+  'taxid',
+  'seed',
+  'mnemonic',
+];
+
+export const REDACTED = '[REDACTED]';
+export const TRUNCATED_SUFFIX = '…[truncated]';
+
+export interface RedactionOptions {
+  /** Maximum object/array nesting before the branch is collapsed. */
+  maxDepth?: number;
+  /** Maximum number of array entries retained. */
+  maxArrayLength?: number;
+  /** Maximum string length retained before truncation. */
+  maxStringLength?: number;
+  /** Maximum number of keys retained per object. */
+  maxKeys?: number;
+}
+
+const DEFAULTS: Required<RedactionOptions> = {
+  maxDepth: 5,
+  maxArrayLength: 20,
+  maxStringLength: 512,
+  maxKeys: 50,
+};
+
+/** Lower-cases and drops separators so `card_number`, `card-number` and
+ * `cardNumber` all normalise to the same comparable form. */
+const normalizeKey = (key: string): string =>
+  key.toLowerCase().replace(/[-_\s]/g, '');
+
+export function isSensitiveKey(key: string): boolean {
+  const normalized = normalizeKey(key);
+  return SENSITIVE_KEY_PATTERNS.some((pattern) =>
+    normalized.includes(normalizeKey(pattern)),
+  );
+}
+
+/**
+ * Masks an email so an auditor can still correlate accounts without the
+ * collection becoming a harvestable address list: `ada@example.com` → `a***@example.com`.
+ */
+export function maskEmail(value: string): string {
+  const at = value.indexOf('@');
+  if (at <= 0) return value;
+  const local = value.slice(0, at);
+  const domain = value.slice(at);
+  const head = local[0];
+  return `${head}${'*'.repeat(Math.max(local.length - 1, 1))}${domain}`;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Recursively copies `value` into a plain, storage-safe structure with
+ * sensitive keys removed, oversized strings truncated and cycles broken.
+ */
+export function redactMetadata(
+  value: unknown,
+  options: RedactionOptions = {},
+): unknown {
+  const opts = { ...DEFAULTS, ...options };
+  return walk(value, opts, 0, new WeakSet<object>());
+}
+
+function walk(
+  value: unknown,
+  opts: Required<RedactionOptions>,
+  depth: number,
+  seen: WeakSet<object>,
+): unknown {
+  if (value === null || value === undefined) return null;
+
+  const type = typeof value;
+
+  if (type === 'string') {
+    const str = value as string;
+    if (EMAIL_RE.test(str)) return maskEmail(str);
+    return str.length > opts.maxStringLength
+      ? str.slice(0, opts.maxStringLength) + TRUNCATED_SUFFIX
+      : str;
+  }
+
+  if (type === 'number' || type === 'boolean') return value;
+  if (type === 'bigint') return (value as bigint).toString();
+  if (type === 'function' || type === 'symbol') return '[unsupported]';
+
+  if (value instanceof Date) return value.toISOString();
+  if (Buffer.isBuffer(value)) return `[buffer:${value.length}]`;
+
+  // Mongoose documents / ObjectIds expose their own serialisation
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.toHexString === 'function') {
+    return (obj.toHexString as () => string)();
+  }
+  if (typeof obj.toObject === 'function') {
+    return walk((obj.toObject as () => unknown)(), opts, depth, seen);
+  }
+
+  if (seen.has(value)) return '[circular]';
+  if (depth >= opts.maxDepth) return '[depth-limit]';
+  seen.add(value);
+
+  try {
+    if (Array.isArray(value)) {
+      const kept = value.slice(0, opts.maxArrayLength);
+      const out: unknown[] = kept.map((entry) =>
+        walk(entry, opts, depth + 1, seen),
+      );
+      if (value.length > opts.maxArrayLength) {
+        out.push(`[+${value.length - opts.maxArrayLength} more]`);
+      }
+      return out;
+    }
+
+    const entries = Object.entries(obj).filter(
+      ([, entryValue]) => typeof entryValue !== 'undefined',
+    );
+    const result: Record<string, unknown> = {};
+    for (const [key, entryValue] of entries.slice(0, opts.maxKeys)) {
+      result[key] = isSensitiveKey(key)
+        ? REDACTED
+        : walk(entryValue, opts, depth + 1, seen);
+    }
+    if (entries.length > opts.maxKeys) {
+      result['__truncatedKeys'] = entries.length - opts.maxKeys;
+    }
+    return result;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+/**
+ * Picks a stable subset of fields from a document for before/after snapshots.
+ * Keeping snapshots narrow limits both storage growth and leak surface.
+ */
+export function snapshot<T extends object>(
+  source: T | null | undefined,
+  fields: readonly string[],
+): Record<string, unknown> | null {
+  if (!source) return null;
+  const plain =
+    typeof (source as { toObject?: () => T }).toObject === 'function'
+      ? (source as { toObject: () => T }).toObject()
+      : source;
+  const out: Record<string, unknown> = {};
+  for (const field of fields) {
+    const value = (plain as Record<string, unknown>)[field];
+    if (typeof value !== 'undefined') out[field] = value;
+  }
+  return redactMetadata(out) as Record<string, unknown>;
+}

--- a/src/common/audit/audit.module.ts
+++ b/src/common/audit/audit.module.ts
@@ -1,0 +1,20 @@
+import { Global, Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AuditService } from './audit.service';
+import { AuditLog, AuditLogSchema } from './schemas/audit-log.schema';
+
+/**
+ * Global so every feature module can inject {@link AuditService} without
+ * re-importing the audit model. Imported once from AppModule.
+ */
+@Global()
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: AuditLog.name, schema: AuditLogSchema },
+    ]),
+  ],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/src/common/audit/audit.service.spec.ts
+++ b/src/common/audit/audit.service.spec.ts
@@ -1,0 +1,276 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getModelToken } from '@nestjs/mongoose';
+import { AuditService, canonicalize } from './audit.service';
+import { AuditAction, AuditOutcome } from './audit-action.enum';
+import { AuditContext } from './audit-context';
+import { REDACTED } from './audit-redaction';
+import { AuditLog } from './schemas/audit-log.schema';
+
+const context: AuditContext = {
+  actorId: 'admin-1',
+  actorEmail: 'admin@chainverse.io',
+  actorRole: 'admin',
+  requestId: 'req-abc-123',
+  ip: '10.0.0.5',
+  userAgent: 'jest',
+};
+
+const config: Record<string, unknown> = {};
+
+/** Model double that records what would have been persisted. */
+const saved: Record<string, unknown>[] = [];
+let saveImpl: jest.Mock;
+
+const mockAuditModel: any = jest.fn().mockImplementation(function (
+  this: any,
+  payload: Record<string, unknown>,
+) {
+  Object.assign(this, payload);
+  this.save = () => saveImpl(payload);
+});
+
+describe('AuditService', () => {
+  let service: AuditService;
+
+  beforeEach(async () => {
+    saved.length = 0;
+    for (const key of Object.keys(config)) delete config[key];
+    config['jwtSecret'] = 'unit-test-secret';
+
+    saveImpl = jest.fn().mockImplementation((payload) => {
+      saved.push(payload);
+      return Promise.resolve(payload);
+    });
+    mockAuditModel.mockClear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        { provide: getModelToken(AuditLog.name), useValue: mockAuditModel },
+        {
+          provide: ConfigService,
+          useValue: { get: (key: string) => config[key] },
+        },
+      ],
+    }).compile();
+
+    service = module.get(AuditService);
+  });
+
+  describe('record', () => {
+    it('captures actor, action, target, request ID and timestamp', async () => {
+      await service.record({
+        action: AuditAction.COURSE_REVIEWED,
+        context,
+        target: { type: 'course', id: 'course-9' },
+      });
+
+      expect(saved).toHaveLength(1);
+      const entry = saved[0] as any;
+
+      expect(entry.action).toBe('course.reviewed');
+      expect(entry.actor).toEqual({
+        id: 'admin-1',
+        email: 'admin@chainverse.io',
+        role: 'admin',
+        ip: '10.0.0.5',
+        userAgent: 'jest',
+      });
+      expect(entry.target).toEqual({ type: 'course', id: 'course-9' });
+      expect(entry.requestId).toBe('req-abc-123');
+      expect(entry.timestamp).toBeInstanceOf(Date);
+      expect(entry.outcome).toBe(AuditOutcome.SUCCESS);
+      expect(typeof entry.integrityHash).toBe('string');
+    });
+
+    it('redacts sensitive fields in before/after snapshots', async () => {
+      await service.record({
+        action: AuditAction.ADMIN_ACCOUNT_UPDATED,
+        context,
+        target: { type: 'admin_account', id: 'acct-1' },
+        before: { email: 'old@chainverse.io', password: 'old-secret' },
+        after: { email: 'new@chainverse.io', password: 'new-secret' },
+      });
+
+      const entry = saved[0] as any;
+      expect(entry.before.password).toBe(REDACTED);
+      expect(entry.after.password).toBe(REDACTED);
+      expect(entry.before.email).toBe('o**@chainverse.io');
+    });
+
+    it('normalises absent snapshots to null', async () => {
+      await service.record({
+        action: AuditAction.ORGANIZATION_CREATED,
+        context,
+        target: { type: 'organization', id: 'org-1' },
+      });
+
+      const entry = saved[0] as any;
+      expect(entry.before).toBeNull();
+      expect(entry.after).toBeNull();
+      expect(entry.reason).toBeNull();
+    });
+
+    it('records denials, not just successful mutations', async () => {
+      await service.record({
+        action: AuditAction.FILE_UPLOAD_REJECTED,
+        context,
+        target: { type: 'worker_upload', id: null },
+        outcome: AuditOutcome.DENIED,
+        reason: 'magic bytes mismatch',
+      });
+
+      const entry = saved[0] as any;
+      expect(entry.outcome).toBe(AuditOutcome.DENIED);
+      expect(entry.reason).toBe('magic bytes mismatch');
+      expect(entry.target.id).toBeNull();
+    });
+
+    it('fails open by default so an audit outage cannot break the mutation', async () => {
+      saveImpl = jest.fn().mockRejectedValue(new Error('mongo down'));
+
+      await expect(
+        service.record({
+          action: AuditAction.COURSE_DELETED,
+          context,
+          target: { type: 'course', id: 'c-1' },
+        }),
+      ).resolves.toBeNull();
+    });
+
+    it('propagates the failure when AUDIT_LOG_FAIL_CLOSED is set', async () => {
+      config['audit.failClosed'] = true;
+      saveImpl = jest.fn().mockRejectedValue(new Error('mongo down'));
+
+      await expect(
+        service.record({
+          action: AuditAction.COURSE_DELETED,
+          context,
+          target: { type: 'course', id: 'c-1' },
+        }),
+      ).rejects.toThrow('mongo down');
+    });
+  });
+
+  describe('integrity hash', () => {
+    it('verifies an untouched entry', () => {
+      const payload = service.buildPayload({
+        action: AuditAction.COURSE_PUBLISHED,
+        context,
+        target: { type: 'course', id: 'course-9' },
+        after: { status: 'published' },
+      });
+
+      expect(service.verify(payload as never)).toBe(true);
+    });
+
+    it('detects a tampered field', () => {
+      const payload = service.buildPayload({
+        action: AuditAction.COURSE_PUBLISHED,
+        context,
+        target: { type: 'course', id: 'course-9' },
+      });
+
+      payload.action = AuditAction.COURSE_DELETED;
+
+      expect(service.verify(payload as never)).toBe(false);
+    });
+
+    it('detects a tampered actor', () => {
+      const payload = service.buildPayload({
+        action: AuditAction.COURSE_DELETED,
+        context,
+        target: { type: 'course', id: 'course-9' },
+      });
+
+      payload.actor.id = 'someone-else';
+
+      expect(service.verify(payload as never)).toBe(false);
+    });
+
+    it('rejects an entry with a truncated hash instead of throwing', () => {
+      const payload = service.buildPayload({
+        action: AuditAction.COURSE_DELETED,
+        context,
+        target: { type: 'course', id: 'c-1' },
+      });
+
+      payload.integrityHash = 'deadbeef';
+
+      expect(service.verify(payload as never)).toBe(false);
+    });
+
+    it('rejects an entry with no hash at all', () => {
+      expect(service.verify({ action: 'course.deleted' })).toBe(false);
+    });
+
+    it('is stable regardless of property order', () => {
+      const a = service.computeIntegrityHash({ x: 1, y: 2 });
+      const b = service.computeIntegrityHash({ y: 2, x: 1 });
+
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('onModuleInit', () => {
+    it('warns in production when no dedicated audit key is configured', () => {
+      config['nodeEnv'] = 'production';
+      const warn = jest
+        .spyOn((service as any).logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      service.onModuleInit();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('AUDIT_HMAC_SECRET is not set'),
+      );
+    });
+
+    it('stays quiet when a dedicated audit key is configured', () => {
+      config['nodeEnv'] = 'production';
+      config['audit.hmacSecret'] = 'a-dedicated-audit-secret-of-length-32+';
+      const warn = jest
+        .spyOn((service as any).logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      service.onModuleInit();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('stays quiet outside production', () => {
+      config['nodeEnv'] = 'development';
+      const warn = jest
+        .spyOn((service as any).logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      service.onModuleInit();
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('prefers the dedicated key over jwtSecret for hashing', () => {
+      config['audit.hmacSecret'] = 'dedicated-audit-secret';
+      const withDedicated = service.computeIntegrityHash({ a: 1 });
+
+      delete config['audit.hmacSecret'];
+      const withFallback = service.computeIntegrityHash({ a: 1 });
+
+      expect(withDedicated).not.toBe(withFallback);
+    });
+  });
+
+  describe('canonicalize', () => {
+    it('sorts keys and serialises dates deterministically', () => {
+      expect(
+        canonicalize({ b: 1, a: new Date('2026-01-01T00:00:00.000Z') }),
+      ).toBe('{"a":"2026-01-01T00:00:00.000Z","b":1}');
+    });
+
+    it('treats null and undefined identically', () => {
+      expect(canonicalize(null)).toBe('null');
+      expect(canonicalize(undefined)).toBe('null');
+    });
+  });
+});

--- a/src/common/audit/audit.service.ts
+++ b/src/common/audit/audit.service.ts
@@ -1,0 +1,218 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import * as crypto from 'crypto';
+import { AuditAction, AuditOutcome } from './audit-action.enum';
+import { AuditContext } from './audit-context';
+import { redactMetadata } from './audit-redaction';
+import { AuditLog, AuditLogDocument } from './schemas/audit-log.schema';
+
+export interface AuditEntryInput {
+  action: AuditAction | string;
+  context: AuditContext;
+  target: { type: string; id?: string | null };
+  outcome?: AuditOutcome;
+  /** State before the mutation; redacted before storage. */
+  before?: unknown;
+  /** State after the mutation; redacted before storage. */
+  after?: unknown;
+  reason?: string | null;
+}
+
+/** Storage-ready audit entry, as written to the collection. */
+export interface AuditLogPayload {
+  action: string;
+  actor: {
+    id: string;
+    email: string | null;
+    role: string | null;
+    ip: string | null;
+    userAgent: string | null;
+  };
+  target: { type: string; id: string | null };
+  requestId: string;
+  timestamp: Date;
+  outcome: AuditOutcome;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  reason: string | null;
+  integrityHash: string;
+}
+
+@Injectable()
+export class AuditService implements OnModuleInit {
+  private readonly logger = new Logger(AuditService.name);
+
+  constructor(
+    @InjectModel(AuditLog.name)
+    private readonly auditLogModel: Model<AuditLogDocument>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  onModuleInit(): void {
+    const isProduction =
+      this.configService.get<string>('nodeEnv') === 'production';
+
+    if (isProduction && !this.configService.get<string>('audit.hmacSecret')) {
+      // Sharing the key with JWT_SECRET means a JWT rotation silently
+      // invalidates the integrity hash of every historical audit entry.
+      this.logger.warn(
+        'AUDIT_HMAC_SECRET is not set; falling back to JWT_SECRET. ' +
+          'Rotating JWT_SECRET will invalidate historical audit integrity hashes. ' +
+          'Set a dedicated AUDIT_HMAC_SECRET in production.',
+      );
+    }
+  }
+
+  /**
+   * Appends an audit entry.
+   *
+   * Persistence failures do not propagate by default so an audit outage cannot
+   * fail an otherwise successful privileged mutation; set
+   * `AUDIT_LOG_FAIL_CLOSED=true` to make the mutation fail instead.
+   */
+  async record(entry: AuditEntryInput): Promise<AuditLogDocument | null> {
+    const payload = this.buildPayload(entry);
+
+    try {
+      return await new this.auditLogModel(payload).save();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to persist audit entry action=${payload.action} requestId=${payload.requestId}: ${message}`,
+      );
+      if (this.failClosed) {
+        throw err;
+      }
+      return null;
+    }
+  }
+
+  /** Builds the storage-ready entry, including its integrity hash. */
+  buildPayload(entry: AuditEntryInput): AuditLogPayload {
+    const { context } = entry;
+    const timestamp = new Date();
+
+    const base = {
+      action: entry.action,
+      actor: {
+        id: context.actorId,
+        email: context.actorEmail,
+        role: context.actorRole,
+        ip: context.ip,
+        userAgent: context.userAgent,
+      },
+      target: {
+        type: entry.target.type,
+        id: entry.target.id ?? null,
+      },
+      requestId: context.requestId,
+      timestamp,
+      outcome: entry.outcome ?? AuditOutcome.SUCCESS,
+      before: (redactMetadata(entry.before ?? null) ?? null) as Record<
+        string,
+        unknown
+      > | null,
+      after: (redactMetadata(entry.after ?? null) ?? null) as Record<
+        string,
+        unknown
+      > | null,
+      reason: entry.reason ?? null,
+    };
+
+    return { ...base, integrityHash: this.computeIntegrityHash(base) };
+  }
+
+  /**
+   * HMAC over the canonical (key-sorted) entry. Any later edit to a stored row
+   * makes the recomputed hash diverge, which {@link verify} reports.
+   */
+  computeIntegrityHash(entry: Record<string, unknown>): string {
+    // The hash never covers itself.
+    const rest = Object.fromEntries(
+      Object.entries(entry).filter(([key]) => key !== 'integrityHash'),
+    );
+    return crypto
+      .createHmac('sha256', this.hmacSecret)
+      .update(canonicalize(rest))
+      .digest('hex');
+  }
+
+  /** Returns true when the stored entry still matches its integrity hash. */
+  verify(entry: Partial<AuditLog>): boolean {
+    if (!entry?.integrityHash) return false;
+    const plain =
+      typeof (entry as { toObject?: () => AuditLog }).toObject === 'function'
+        ? (entry as { toObject: () => AuditLog }).toObject()
+        : entry;
+
+    const {
+      action,
+      actor,
+      target,
+      requestId,
+      timestamp,
+      outcome,
+      before,
+      after,
+      reason,
+    } = plain as AuditLog;
+
+    const expected = this.computeIntegrityHash({
+      action,
+      actor,
+      target,
+      requestId,
+      timestamp,
+      outcome,
+      before: before ?? null,
+      after: after ?? null,
+      reason: reason ?? null,
+    });
+
+    const stored = Buffer.from(entry.integrityHash);
+    const candidate = Buffer.from(expected);
+    // timingSafeEqual throws on length mismatch, which itself means tampering.
+    return (
+      stored.length === candidate.length &&
+      crypto.timingSafeEqual(candidate, stored)
+    );
+  }
+
+  private get hmacSecret(): string {
+    return (
+      this.configService.get<string>('audit.hmacSecret') ??
+      this.configService.get<string>('jwtSecret') ??
+      'chainverse-audit-development-secret'
+    );
+  }
+
+  private get failClosed(): boolean {
+    return this.configService.get<boolean>('audit.failClosed') === true;
+  }
+}
+
+/**
+ * Deterministic JSON with sorted keys, so hash stability does not depend on
+ * property insertion order.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => typeof entryValue !== 'undefined')
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return `{${entries
+      .map(
+        ([key, entryValue]) =>
+          `${JSON.stringify(key)}:${canonicalize(entryValue)}`,
+      )
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/src/common/audit/index.ts
+++ b/src/common/audit/index.ts
@@ -1,0 +1,28 @@
+export { AuditAction, AuditOutcome } from './audit-action.enum';
+export {
+  AuditActor,
+  resolveAuditContext,
+  systemAuditContext,
+} from './audit-context';
+export type { AuditContext } from './audit-context';
+export { AuditModule } from './audit.module';
+export { AuditService, canonicalize } from './audit.service';
+export type { AuditEntryInput } from './audit.service';
+export {
+  isSensitiveKey,
+  maskEmail,
+  redactMetadata,
+  snapshot,
+  REDACTED,
+  SENSITIVE_KEY_PATTERNS,
+} from './audit-redaction';
+export {
+  AuditLog,
+  AuditLogSchema,
+  AuditLogImmutableError,
+  applyAuditImmutability,
+  assertInsertOnly,
+  rejectMutation,
+  FORBIDDEN_AUDIT_OPERATIONS,
+} from './schemas/audit-log.schema';
+export type { AuditLogDocument } from './schemas/audit-log.schema';

--- a/src/common/audit/schemas/audit-log.schema.spec.ts
+++ b/src/common/audit/schemas/audit-log.schema.spec.ts
@@ -1,0 +1,103 @@
+import { Schema } from 'mongoose';
+import {
+  applyAuditImmutability,
+  assertInsertOnly,
+  AuditLogImmutableError,
+  AuditLogSchema,
+  FORBIDDEN_AUDIT_OPERATIONS,
+  rejectMutation,
+} from './audit-log.schema';
+
+/** Names of the operations a schema has registered `pre` middleware for. */
+function registeredPreHooks(schema: Schema): string[] {
+  const hooks = (
+    schema as unknown as { s: { hooks: { _pres: Map<string, unknown[]> } } }
+  ).s.hooks;
+  return Array.from(hooks._pres.keys());
+}
+
+describe('AuditLog schema immutability', () => {
+  describe('guards', () => {
+    it.each([...FORBIDDEN_AUDIT_OPERATIONS])(
+      'rejectMutation refuses %s and names it in the message',
+      (operation) => {
+        expect(() => rejectMutation(operation)).toThrow(AuditLogImmutableError);
+        expect(() => rejectMutation(operation)).toThrow(operation);
+      },
+    );
+
+    it('allows inserting a brand new entry', () => {
+      expect(() => assertInsertOnly({ isNew: true })).not.toThrow();
+    });
+
+    it('refuses re-saving an already persisted entry', () => {
+      expect(() => assertInsertOnly({ isNew: false })).toThrow(
+        AuditLogImmutableError,
+      );
+      expect(() => assertInsertOnly({ isNew: false })).toThrow(
+        'update of existing entry',
+      );
+    });
+  });
+
+  describe('registration', () => {
+    it('registers a pre hook for every forbidden operation', () => {
+      const registered = registeredPreHooks(AuditLogSchema);
+
+      for (const operation of FORBIDDEN_AUDIT_OPERATIONS) {
+        expect(registered).toContain(operation);
+      }
+    });
+
+    it('registers hooks for save and bulkWrite', () => {
+      const registered = registeredPreHooks(AuditLogSchema);
+
+      expect(registered).toContain('save');
+      expect(registered).toContain('bulkWrite');
+    });
+
+    it('can be applied to any schema, not just the built-in one', () => {
+      const schema = new Schema({ value: String });
+      applyAuditImmutability(schema);
+
+      expect(registeredPreHooks(schema)).toContain('deleteMany');
+    });
+
+    it('actually throws when the registered updateOne hook runs', () => {
+      const schema = new Schema({ value: String });
+      applyAuditImmutability(schema);
+
+      const hooks = (
+        schema as unknown as {
+          s: { hooks: { _pres: Map<string, Array<{ fn: () => void }>> } };
+        }
+      ).s.hooks;
+      const [hook] = hooks._pres.get('updateOne')!;
+
+      expect(() => hook.fn.call({})).toThrow(AuditLogImmutableError);
+    });
+  });
+
+  describe('storage shape', () => {
+    it('stores timestamps under recordedAt and never updates them', () => {
+      expect(AuditLogSchema.get('timestamps')).toEqual({
+        createdAt: 'recordedAt',
+        updatedAt: false,
+      });
+    });
+
+    it('writes to a dedicated collection with no version key', () => {
+      expect(AuditLogSchema.get('collection')).toBe('audit_logs');
+      expect(AuditLogSchema.get('versionKey')).toBe(false);
+    });
+
+    it('indexes the fields audit reviews actually query', () => {
+      const indexed = AuditLogSchema.indexes().map(([fields]) =>
+        Object.keys(fields).join(','),
+      );
+
+      expect(indexed).toContain('actor.id,timestamp');
+      expect(indexed).toContain('target.type,target.id,timestamp');
+    });
+  });
+});

--- a/src/common/audit/schemas/audit-log.schema.ts
+++ b/src/common/audit/schemas/audit-log.schema.ts
@@ -1,0 +1,146 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
+import { AuditOutcome } from '../audit-action.enum';
+
+export type AuditLogDocument = HydratedDocument<AuditLog>;
+
+export class AuditActorSnapshot {
+  id: string;
+  email: string | null;
+  role: string | null;
+  ip: string | null;
+  userAgent: string | null;
+}
+
+export class AuditTargetSnapshot {
+  type: string;
+  id: string | null;
+}
+
+/**
+ * Append-only record of a privileged mutation.
+ *
+ * Immutability is enforced at three layers:
+ *  1. `applyAuditImmutability` rejects every update/delete query on the model.
+ *  2. A `pre('save')` hook rejects saving an already-persisted document.
+ *  3. `integrityHash` is an HMAC over the entry, so out-of-band tampering
+ *     (e.g. direct `mongosh` writes) is detectable via `AuditService.verify`.
+ */
+@Schema({
+  collection: 'audit_logs',
+  versionKey: false,
+  timestamps: { createdAt: 'recordedAt', updatedAt: false },
+})
+export class AuditLog {
+  /** Value from {@link AuditAction}. */
+  @Prop({ required: true, index: true })
+  action: string;
+
+  /** Who performed the action. */
+  @Prop({ type: MongooseSchema.Types.Mixed, required: true })
+  actor: AuditActorSnapshot;
+
+  /** What the action was performed on. */
+  @Prop({ type: MongooseSchema.Types.Mixed, required: true })
+  target: AuditTargetSnapshot;
+
+  /** Correlation ID from `X-Request-Id`, set by RequestIdMiddleware. */
+  @Prop({ required: true, index: true })
+  requestId: string;
+
+  /** When the action happened (distinct from `recordedAt`, when it was stored). */
+  @Prop({ type: Date, required: true, default: () => new Date(), index: true })
+  timestamp: Date;
+
+  @Prop({
+    required: true,
+    enum: Object.values(AuditOutcome),
+    default: AuditOutcome.SUCCESS,
+  })
+  outcome: string;
+
+  /** Redacted state before the mutation; `null` for creations. */
+  @Prop({ type: MongooseSchema.Types.Mixed, default: null })
+  before: Record<string, unknown> | null;
+
+  /** Redacted state after the mutation; `null` for deletions. */
+  @Prop({ type: MongooseSchema.Types.Mixed, default: null })
+  after: Record<string, unknown> | null;
+
+  /** Operator-supplied justification, where the endpoint collects one. */
+  @Prop({ type: String, default: null })
+  reason: string | null;
+
+  /** HMAC-SHA256 over the canonical entry payload. */
+  @Prop({ required: true })
+  integrityHash: string;
+
+  readonly recordedAt?: Date;
+}
+
+export const AuditLogSchema = SchemaFactory.createForClass(AuditLog);
+
+/** Query methods that would mutate or remove existing audit entries. */
+export const FORBIDDEN_AUDIT_OPERATIONS = [
+  'updateOne',
+  'updateMany',
+  'replaceOne',
+  'findOneAndUpdate',
+  'findOneAndReplace',
+  'findOneAndDelete',
+  'findOneAndRemove',
+  'deleteOne',
+  'deleteMany',
+  'remove',
+] as const;
+
+export class AuditLogImmutableError extends Error {
+  constructor(operation: string) {
+    super(
+      `Audit log entries are append-only; "${operation}" is not permitted on audit_logs`,
+    );
+    this.name = 'AuditLogImmutableError';
+  }
+}
+
+/** Always throws — the body of every forbidden-operation hook. */
+export function rejectMutation(operation: string): never {
+  throw new AuditLogImmutableError(operation);
+}
+
+/**
+ * Guard for `pre('save')`: creating an entry is fine, re-saving a persisted one
+ * is not.
+ */
+export function assertInsertOnly(document: { isNew: boolean }): void {
+  if (!document.isNew) {
+    throw new AuditLogImmutableError('save (update of existing entry)');
+  }
+}
+
+/**
+ * Installs the append-only guards. Exported separately so the behaviour can be
+ * unit-tested against a bare schema without a live connection.
+ */
+export function applyAuditImmutability(schema: MongooseSchema): void {
+  for (const operation of FORBIDDEN_AUDIT_OPERATIONS) {
+    schema.pre(operation as 'updateOne', function () {
+      rejectMutation(operation);
+    });
+  }
+
+  schema.pre('save', function (this: { isNew: boolean }) {
+    assertInsertOnly(this);
+  });
+
+  // Bulk paths bypass the query middleware above, so block them too.
+  schema.pre('bulkWrite', function () {
+    rejectMutation('bulkWrite');
+  });
+}
+
+applyAuditImmutability(AuditLogSchema);
+
+// Common review queries: "what did this actor do", "what happened to this target".
+AuditLogSchema.index({ 'actor.id': 1, timestamp: -1 });
+AuditLogSchema.index({ 'target.type': 1, 'target.id': 1, timestamp: -1 });

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -61,6 +61,35 @@ export const envValidationSchema = Joi.object({
 
   // Application base URL used for verification / reset links in emails
   BASE_URL: Joi.string().uri().default('http://localhost:3000'),
+
+  // ─── Audit logging ──────────────────────────────────────────────────────────
+  // Dedicated HMAC key for audit-entry integrity hashes. Optional: when unset
+  // the service falls back to JWT_SECRET, which keeps existing deployments
+  // working. Setting it is strongly recommended in production — sharing the key
+  // with JWT_SECRET means rotating that secret silently invalidates the
+  // integrity hash of every historical audit entry. AuditService logs a warning
+  // at startup when it is missing in production.
+  AUDIT_HMAC_SECRET: Joi.string().min(32).optional(),
+
+  // When true, a failed audit write also fails the mutation being audited.
+  AUDIT_LOG_FAIL_CLOSED: Joi.boolean().default(false),
+
+  // ─── Uploads: quarantine, scanning and quotas ───────────────────────────────
+  // Storage root for uploaded files. Must be outside any web-served directory.
+  UPLOAD_STORAGE_ROOT: Joi.string().default('var/uploads'),
+  UPLOAD_MAX_FILE_BYTES: Joi.number().integer().positive().default(5242880),
+  UPLOAD_QUOTA_MAX_BYTES: Joi.number().integer().positive().default(104857600),
+  UPLOAD_QUOTA_MAX_FILES: Joi.number().integer().positive().default(20),
+  UPLOAD_QUOTA_WINDOW_MS: Joi.number().integer().positive().default(86400000),
+  // Retain infected samples under `infected/` instead of deleting them.
+  UPLOAD_RETAIN_INFECTED: Joi.boolean().default(false),
+
+  MALWARE_SCAN_PROVIDER: Joi.string()
+    .valid('builtin', 'clamav')
+    .default('builtin'),
+  MALWARE_SCAN_HOST: Joi.string().default('127.0.0.1'),
+  MALWARE_SCAN_PORT: Joi.number().port().default(3310),
+  MALWARE_SCAN_TIMEOUT_MS: Joi.number().integer().positive().default(30000),
 });
 
 /**

--- a/src/common/decorators/org-membership.decorator.ts
+++ b/src/common/decorators/org-membership.decorator.ts
@@ -1,0 +1,13 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { ResolvedOrgMembership } from '../guards/organization-roles.guard';
+
+/**
+ * Injects the membership resolved by `OrganizationRolesGuard`.
+ *
+ * Only meaningful on handlers guarded by `OrganizationRolesGuard`; elsewhere it
+ * resolves to `undefined`.
+ */
+export const OrgMembership = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): ResolvedOrgMembership | undefined =>
+    ctx.switchToHttp().getRequest()?.organizationMembership,
+);

--- a/src/common/decorators/org-roles.decorator.ts
+++ b/src/common/decorators/org-roles.decorator.ts
@@ -1,0 +1,34 @@
+import { SetMetadata } from '@nestjs/common';
+import { OrganizationRole } from '../enums/organization-role.enum';
+
+export const ORG_ROLES_KEY = 'orgRoles';
+export const ORG_SCOPE_KEY = 'orgScope';
+
+/**
+ * Declares which organization roles may invoke a handler. Any listed role is
+ * sufficient (the guard does not imply a hierarchy — list roles explicitly so
+ * each route's intent is readable at the call site).
+ */
+export const OrgRoles = (...roles: OrganizationRole[]) =>
+  SetMetadata(ORG_ROLES_KEY, roles);
+
+export type OrgScopeSource = 'param' | 'body' | 'query' | 'membershipParam';
+
+export interface OrgScopeOptions {
+  /**
+   * Where the organization is identified:
+   *  - `param` / `body` / `query`: read the organization id from that location
+   *  - `membershipParam`: the value is an OrganizationMember id; the guard
+   *    loads that membership and scopes to its `organizationId`
+   */
+  source: OrgScopeSource;
+  /** Property name to read from the chosen source. */
+  key: string;
+}
+
+/**
+ * Tells {@link OrganizationRolesGuard} how to find the organization a request
+ * targets. Required on every handler that carries `@OrgRoles`.
+ */
+export const OrgScope = (options: OrgScopeOptions) =>
+  SetMetadata(ORG_SCOPE_KEY, options);

--- a/src/common/enums/organization-role.enum.spec.ts
+++ b/src/common/enums/organization-role.enum.spec.ts
@@ -1,0 +1,71 @@
+import {
+  isOrganizationRole,
+  ORGANIZATION_ROLE_HIERARCHY,
+  OrganizationRole,
+  organizationRoleSatisfies,
+} from './organization-role.enum';
+
+describe('OrganizationRole', () => {
+  it('expresses the four organization-scoped roles', () => {
+    expect(ORGANIZATION_ROLE_HIERARCHY).toEqual([
+      OrganizationRole.OWNER,
+      OrganizationRole.ADMIN,
+      OrganizationRole.INSTRUCTOR,
+      OrganizationRole.MEMBER,
+    ]);
+  });
+
+  describe('isOrganizationRole', () => {
+    it.each(Object.values(OrganizationRole))('accepts %s', (role) => {
+      expect(isOrganizationRole(role)).toBe(true);
+    });
+
+    it.each([
+      ['a platform role', 'student'],
+      ['an unknown string', 'superuser'],
+      ['a non-string', 42],
+      ['null', null],
+      ['undefined', undefined],
+    ])('rejects %s', (_label, value) => {
+      expect(isOrganizationRole(value)).toBe(false);
+    });
+  });
+
+  describe('organizationRoleSatisfies', () => {
+    it('lets a higher role satisfy a lower requirement', () => {
+      expect(
+        organizationRoleSatisfies(
+          OrganizationRole.OWNER,
+          OrganizationRole.MEMBER,
+        ),
+      ).toBe(true);
+      expect(
+        organizationRoleSatisfies(
+          OrganizationRole.ADMIN,
+          OrganizationRole.INSTRUCTOR,
+        ),
+      ).toBe(true);
+    });
+
+    it('does not let a lower role satisfy a higher requirement', () => {
+      expect(
+        organizationRoleSatisfies(
+          OrganizationRole.MEMBER,
+          OrganizationRole.OWNER,
+        ),
+      ).toBe(false);
+      expect(
+        organizationRoleSatisfies(
+          OrganizationRole.INSTRUCTOR,
+          OrganizationRole.ADMIN,
+        ),
+      ).toBe(false);
+    });
+
+    it('treats a role as satisfying itself', () => {
+      for (const role of ORGANIZATION_ROLE_HIERARCHY) {
+        expect(organizationRoleSatisfies(role, role)).toBe(true);
+      }
+    });
+  });
+});

--- a/src/common/enums/organization-role.enum.ts
+++ b/src/common/enums/organization-role.enum.ts
@@ -1,0 +1,42 @@
+/**
+ * Roles a principal can hold *inside* a single organization.
+ *
+ * These are orthogonal to the platform-wide {@link Role} enum: a user with the
+ * global `student` role can be the `owner` of their own organization, and a
+ * global `tutor` has no organization powers unless a membership grants them.
+ */
+export enum OrganizationRole {
+  OWNER = 'owner',
+  ADMIN = 'admin',
+  INSTRUCTOR = 'instructor',
+  MEMBER = 'member',
+}
+
+/** Highest privilege first — index doubles as the precedence rank. */
+export const ORGANIZATION_ROLE_HIERARCHY: readonly OrganizationRole[] = [
+  OrganizationRole.OWNER,
+  OrganizationRole.ADMIN,
+  OrganizationRole.INSTRUCTOR,
+  OrganizationRole.MEMBER,
+];
+
+export function isOrganizationRole(value: unknown): value is OrganizationRole {
+  return (
+    typeof value === 'string' &&
+    (ORGANIZATION_ROLE_HIERARCHY as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * True when `role` is at least as privileged as `minimum`.
+ * `owner` outranks `admin` outranks `instructor` outranks `member`.
+ */
+export function organizationRoleSatisfies(
+  role: OrganizationRole,
+  minimum: OrganizationRole,
+): boolean {
+  return (
+    ORGANIZATION_ROLE_HIERARCHY.indexOf(role) <=
+    ORGANIZATION_ROLE_HIERARCHY.indexOf(minimum)
+  );
+}

--- a/src/common/guards/organization-roles.guard.spec.ts
+++ b/src/common/guards/organization-roles.guard.spec.ts
@@ -1,0 +1,355 @@
+import {
+  ExecutionContext,
+  ForbiddenException,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { OrganizationRolesGuard } from './organization-roles.guard';
+import {
+  ORG_ROLES_KEY,
+  ORG_SCOPE_KEY,
+  OrgScopeOptions,
+} from '../decorators/org-roles.decorator';
+import { OrganizationRole } from '../enums/organization-role.enum';
+import { Role } from '../enums/role.enum';
+import { OrganizationMember } from '../../organization-member/schemas/organization-member.schema';
+
+interface MembershipRow {
+  _id?: string;
+  organizationId: string;
+  userId: string;
+  role: string;
+}
+
+/** In-memory membership store standing in for the Mongoose model. */
+let memberships: MembershipRow[] = [];
+
+const mockMemberModel = {
+  findOne: jest.fn((filter: Record<string, any>) => ({
+    exec: async () =>
+      memberships.find((row) => {
+        if (filter._id && row._id !== filter._id) return false;
+        if (
+          filter.organizationId &&
+          row.organizationId !== filter.organizationId
+        )
+          return false;
+        if (filter.userId && row.userId !== filter.userId) return false;
+        return true;
+      }) ?? null,
+  })),
+};
+
+function makeContext(request: Record<string, unknown>): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+    getHandler: () => 'handler',
+    getClass: () => 'class',
+  } as unknown as ExecutionContext;
+}
+
+describe('OrganizationRolesGuard', () => {
+  let guard: OrganizationRolesGuard;
+  let reflector: Reflector;
+
+  const configureRoute = (
+    roles: OrganizationRole[] | undefined,
+    scope?: OrgScopeOptions,
+  ) => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockImplementation((key: string) => {
+        if (key === ORG_ROLES_KEY) return roles;
+        if (key === ORG_SCOPE_KEY) return scope;
+        return undefined;
+      });
+  };
+
+  beforeEach(async () => {
+    memberships = [
+      {
+        _id: 'm-owner',
+        organizationId: 'org-a',
+        userId: 'u-owner',
+        role: OrganizationRole.OWNER,
+      },
+      {
+        _id: 'm-admin',
+        organizationId: 'org-a',
+        userId: 'u-admin',
+        role: OrganizationRole.ADMIN,
+      },
+      {
+        _id: 'm-instr',
+        organizationId: 'org-a',
+        userId: 'u-instr',
+        role: OrganizationRole.INSTRUCTOR,
+      },
+      {
+        _id: 'm-member',
+        organizationId: 'org-a',
+        userId: 'u-member',
+        role: OrganizationRole.MEMBER,
+      },
+      // Same person, different tenant — the cross-organization case.
+      {
+        _id: 'm-b-owner',
+        organizationId: 'org-b',
+        userId: 'u-b-owner',
+        role: OrganizationRole.OWNER,
+      },
+    ];
+    mockMemberModel.findOne.mockClear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganizationRolesGuard,
+        Reflector,
+        {
+          provide: getModelToken(OrganizationMember.name),
+          useValue: mockMemberModel,
+        },
+      ],
+    }).compile();
+
+    guard = module.get(OrganizationRolesGuard);
+    reflector = module.get(Reflector);
+  });
+
+  it('allows a handler with no @OrgRoles through untouched', async () => {
+    configureRoute(undefined);
+
+    await expect(guard.canActivate(makeContext({}))).resolves.toBe(true);
+  });
+
+  it('fails closed when @OrgScope is missing on a guarded route', async () => {
+    configureRoute([OrganizationRole.OWNER]);
+
+    await expect(
+      guard.canActivate(
+        makeContext({ user: { sub: 'u-owner' }, params: { id: 'org-a' } }),
+      ),
+    ).rejects.toThrow(InternalServerErrorException);
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    configureRoute([OrganizationRole.OWNER], { source: 'param', key: 'id' });
+
+    await expect(
+      guard.canActivate(makeContext({ params: { id: 'org-a' } })),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  describe('membership enforcement', () => {
+    it('allows a member holding a listed role', async () => {
+      configureRoute([OrganizationRole.OWNER, OrganizationRole.ADMIN], {
+        source: 'param',
+        key: 'id',
+      });
+      const request: any = {
+        user: { sub: 'u-admin', role: Role.STUDENT },
+        params: { id: 'org-a' },
+      };
+
+      await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+      expect(request.organizationMembership).toEqual({
+        organizationId: 'org-a',
+        role: OrganizationRole.ADMIN,
+        viaPlatformAdmin: false,
+      });
+    });
+
+    it('denies a member whose role is not listed', async () => {
+      configureRoute([OrganizationRole.OWNER, OrganizationRole.ADMIN], {
+        source: 'param',
+        key: 'id',
+      });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'u-member', role: Role.STUDENT },
+            params: { id: 'org-a' },
+          }),
+        ),
+      ).rejects.toThrow(/not permitted to perform this action/);
+    });
+
+    it('denies an instructor attempting an owner-only action', async () => {
+      configureRoute([OrganizationRole.OWNER], { source: 'param', key: 'id' });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'u-instr', role: Role.TUTOR },
+            params: { id: 'org-a' },
+          }),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('cross-organization denial', () => {
+    it("denies org-b's owner acting on org-a", async () => {
+      configureRoute([OrganizationRole.OWNER, OrganizationRole.ADMIN], {
+        source: 'param',
+        key: 'id',
+      });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'u-b-owner', role: Role.TUTOR },
+            params: { id: 'org-a' },
+          }),
+        ),
+      ).rejects.toThrow('You are not a member of this organization');
+    });
+
+    it("denies org-a's owner acting on org-b", async () => {
+      configureRoute([OrganizationRole.OWNER], { source: 'param', key: 'id' });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'u-owner', role: Role.TUTOR },
+            params: { id: 'org-b' },
+          }),
+        ),
+      ).rejects.toThrow('You are not a member of this organization');
+    });
+
+    it('denies a caller with no membership anywhere', async () => {
+      configureRoute([OrganizationRole.MEMBER], { source: 'param', key: 'id' });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'nobody', role: Role.STUDENT },
+            params: { id: 'org-a' },
+          }),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('denies cross-organization access through the body scope', async () => {
+      configureRoute([OrganizationRole.OWNER, OrganizationRole.ADMIN], {
+        source: 'body',
+        key: 'organizationId',
+      });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'u-b-owner', role: Role.TUTOR },
+            body: { organizationId: 'org-a', userId: 'victim' },
+          }),
+        ),
+      ).rejects.toThrow('You are not a member of this organization');
+    });
+
+    it("denies acting on another organization's membership record", async () => {
+      configureRoute([OrganizationRole.OWNER, OrganizationRole.ADMIN], {
+        source: 'membershipParam',
+        key: 'id',
+      });
+
+      // u-b-owner owns org-b; m-member belongs to org-a.
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'u-b-owner', role: Role.TUTOR },
+            params: { id: 'm-member' },
+          }),
+        ),
+      ).rejects.toThrow('You are not a member of this organization');
+    });
+
+    it("allows acting on a membership inside the caller's own organization", async () => {
+      configureRoute([OrganizationRole.OWNER, OrganizationRole.ADMIN], {
+        source: 'membershipParam',
+        key: 'id',
+      });
+      const request: any = {
+        user: { sub: 'u-owner', role: Role.TUTOR },
+        params: { id: 'm-member' },
+      };
+
+      await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+      expect(request.organizationMembership.organizationId).toBe('org-a');
+      expect(request.organizationMembership.role).toBe(OrganizationRole.OWNER);
+    });
+  });
+
+  describe('scope resolution', () => {
+    it('denies when the organization cannot be determined', async () => {
+      configureRoute([OrganizationRole.OWNER], { source: 'param', key: 'id' });
+
+      await expect(
+        guard.canActivate(
+          makeContext({ user: { sub: 'u-owner' }, params: {} }),
+        ),
+      ).rejects.toThrow('Organization could not be determined');
+    });
+
+    it('denies when the referenced membership does not exist', async () => {
+      configureRoute([OrganizationRole.OWNER], {
+        source: 'membershipParam',
+        key: 'id',
+      });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'u-owner' },
+            params: { id: 'does-not-exist' },
+          }),
+        ),
+      ).rejects.toThrow('Organization could not be determined');
+    });
+  });
+
+  describe('platform admin break-glass', () => {
+    it('permits a platform admin with no membership, and flags the path', async () => {
+      configureRoute([OrganizationRole.OWNER], { source: 'param', key: 'id' });
+      const request: any = {
+        user: { sub: 'platform-admin', role: Role.ADMIN },
+        params: { id: 'org-a' },
+      };
+
+      await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+      expect(request.organizationMembership).toEqual({
+        organizationId: 'org-a',
+        role: OrganizationRole.OWNER,
+        viaPlatformAdmin: true,
+      });
+    });
+
+    it('does not extend the bypass to a platform moderator', async () => {
+      configureRoute([OrganizationRole.OWNER], { source: 'param', key: 'id' });
+
+      await expect(
+        guard.canActivate(
+          makeContext({
+            user: { sub: 'platform-mod', role: Role.MODERATOR },
+            params: { id: 'org-a' },
+          }),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("still honours an admin's real membership role when they have one", async () => {
+      configureRoute([OrganizationRole.MEMBER], { source: 'param', key: 'id' });
+      const request: any = {
+        user: { sub: 'u-member', role: Role.ADMIN },
+        params: { id: 'org-a' },
+      };
+
+      await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+      expect(request.organizationMembership.viaPlatformAdmin).toBe(false);
+    });
+  });
+});

--- a/src/common/guards/organization-roles.guard.ts
+++ b/src/common/guards/organization-roles.guard.ts
@@ -1,0 +1,170 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  ORG_ROLES_KEY,
+  ORG_SCOPE_KEY,
+  OrgScopeOptions,
+} from '../decorators/org-roles.decorator';
+import {
+  isOrganizationRole,
+  OrganizationRole,
+} from '../enums/organization-role.enum';
+import { Role } from '../enums/role.enum';
+import {
+  OrganizationMember,
+  OrganizationMemberDocument,
+} from '../../organization-member/schemas/organization-member.schema';
+
+/** Membership resolved by the guard, attached to the request for handlers. */
+export interface ResolvedOrgMembership {
+  organizationId: string;
+  role: OrganizationRole;
+  /** True when access was granted by the platform `admin` role, not a membership. */
+  viaPlatformAdmin: boolean;
+}
+
+export interface RequestWithOrgMembership {
+  organizationMembership?: ResolvedOrgMembership;
+}
+
+/**
+ * Enforces organization-scoped authorization.
+ *
+ * A global role alone never grants organization powers — the caller must hold a
+ * membership in the *specific* organization the request targets, with one of the
+ * roles listed by `@OrgRoles`. Platform `admin` retains a documented break-glass
+ * bypass so support staff can administer any tenant; that path is flagged on the
+ * resolved membership so callers can audit it.
+ *
+ * Requires `@OrgScope` on the handler to locate the organization id.
+ */
+@Injectable()
+export class OrganizationRolesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    @InjectModel(OrganizationMember.name)
+    private readonly memberModel: Model<OrganizationMemberDocument>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<OrganizationRole[]>(
+      ORG_ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const scope = this.reflector.getAllAndOverride<OrgScopeOptions>(
+      ORG_SCOPE_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!scope) {
+      // A misconfigured route must fail closed rather than allow the request.
+      throw new InternalServerErrorException(
+        'Organization scope is not configured for this route',
+      );
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request?.user as
+      | { sub?: string; id?: string; role?: string }
+      | undefined;
+
+    if (!user || !(user.sub || user.id)) {
+      throw new UnauthorizedException('Authentication is required');
+    }
+
+    const userId = String(user.sub ?? user.id);
+    const organizationId = await this.resolveOrganizationId(request, scope);
+
+    if (!organizationId) {
+      throw new ForbiddenException(
+        'Organization could not be determined for this request',
+      );
+    }
+
+    const membership = await this.memberModel
+      .findOne({ organizationId, userId, deletedAt: null })
+      .exec();
+
+    if (membership && isOrganizationRole(membership.role)) {
+      const role = membership.role;
+      if (requiredRoles.includes(role)) {
+        this.attach(request, {
+          organizationId,
+          role,
+          viaPlatformAdmin: false,
+        });
+        return true;
+      }
+
+      throw new ForbiddenException(
+        `Organization role "${role}" is not permitted to perform this action`,
+      );
+    }
+
+    // Break-glass: platform administrators may act on any organization.
+    if (user.role === Role.ADMIN) {
+      this.attach(request, {
+        organizationId,
+        role: OrganizationRole.OWNER,
+        viaPlatformAdmin: true,
+      });
+      return true;
+    }
+
+    throw new ForbiddenException('You are not a member of this organization');
+  }
+
+  private attach(
+    request: RequestWithOrgMembership,
+    membership: ResolvedOrgMembership,
+  ): void {
+    request.organizationMembership = membership;
+  }
+
+  private async resolveOrganizationId(
+    request: {
+      params?: Record<string, unknown>;
+      body?: Record<string, unknown>;
+      query?: Record<string, unknown>;
+    },
+    scope: OrgScopeOptions,
+  ): Promise<string | null> {
+    const read = (bag?: Record<string, unknown>): string | null => {
+      const value = bag?.[scope.key];
+      return typeof value === 'string' && value.length > 0 ? value : null;
+    };
+
+    switch (scope.source) {
+      case 'param':
+        return read(request.params);
+      case 'body':
+        return read(request.body);
+      case 'query':
+        return read(request.query);
+      case 'membershipParam': {
+        const membershipId = read(request.params);
+        if (!membershipId) return null;
+        const member = await this.memberModel
+          .findOne({ _id: membershipId, deletedAt: null })
+          .exec();
+        return member?.organizationId ?? null;
+      }
+      default:
+        return null;
+    }
+  }
+}

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -36,6 +36,28 @@ export interface AppConfig {
     skipFailed: boolean;
     keyPrefix: string;
   };
+  /** Immutable audit trail for privileged actions. */
+  audit: {
+    /** HMAC key for entry integrity hashes; falls back to `jwtSecret`. */
+    hmacSecret: string | undefined;
+    /** When true, a failed audit write fails the mutation it describes. */
+    failClosed: boolean;
+  };
+  /** Worker upload quarantine, scanning and quota settings. */
+  uploads: {
+    /** Storage root, kept outside any web-served directory. */
+    root: string;
+    maxFileBytes: number;
+    /** Keep infected samples in `infected/` instead of deleting them. */
+    retainInfected: boolean;
+    quota: { maxBytes: number; maxFiles: number; windowMs: number };
+    scanner: {
+      provider: string;
+      host: string;
+      port: number;
+      timeoutMs: number;
+    };
+  };
 }
 
 export default (): AppConfig => ({
@@ -97,5 +119,34 @@ export default (): AppConfig => ({
     skipSuccess: process.env.RATE_LIMIT_SKIP_SUCCESS === 'true',
     skipFailed: process.env.RATE_LIMIT_SKIP_FAILED === 'true',
     keyPrefix: process.env.RATE_LIMIT_KEY_PREFIX ?? 'rl:',
+  },
+  audit: {
+    hmacSecret: process.env.AUDIT_HMAC_SECRET,
+    failClosed: process.env.AUDIT_LOG_FAIL_CLOSED === 'true',
+  },
+  uploads: {
+    root: process.env.UPLOAD_STORAGE_ROOT ?? 'var/uploads',
+    maxFileBytes: parseInt(
+      process.env.UPLOAD_MAX_FILE_BYTES ?? String(5 * 1024 * 1024),
+      10,
+    ),
+    retainInfected: process.env.UPLOAD_RETAIN_INFECTED === 'true',
+    quota: {
+      maxBytes: parseInt(
+        process.env.UPLOAD_QUOTA_MAX_BYTES ?? String(100 * 1024 * 1024),
+        10,
+      ),
+      maxFiles: parseInt(process.env.UPLOAD_QUOTA_MAX_FILES ?? '20', 10),
+      windowMs: parseInt(
+        process.env.UPLOAD_QUOTA_WINDOW_MS ?? String(24 * 60 * 60 * 1000),
+        10,
+      ),
+    },
+    scanner: {
+      provider: process.env.MALWARE_SCAN_PROVIDER ?? 'builtin',
+      host: process.env.MALWARE_SCAN_HOST ?? '127.0.0.1',
+      port: parseInt(process.env.MALWARE_SCAN_PORT ?? '3310', 10),
+      timeoutMs: parseInt(process.env.MALWARE_SCAN_TIMEOUT_MS ?? '30000', 10),
+    },
   },
 });

--- a/src/google-auth/google-auth.service.ts
+++ b/src/google-auth/google-auth.service.ts
@@ -16,11 +16,15 @@ export class GoogleAuthService {
   ) {}
 
   private generateAccessToken(user: GoogleUserDocument): string {
-  private createAccessToken(user: GoogleUserDocument): string {
     return this.jwtService.sign(
       { sub: user.id, email: user.email, role: user.role },
       { expiresIn: ACCESS_TOKEN_EXPIRY },
     );
+  }
+
+  /** Alias kept because both names are called from this service. */
+  private createAccessToken(user: GoogleUserDocument): string {
+    return this.generateAccessToken(user);
   }
 
   async register(

--- a/src/organization-member/dto/create-organization-member.dto.ts
+++ b/src/organization-member/dto/create-organization-member.dto.ts
@@ -1,5 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { OrganizationRole } from '../../common/enums/organization-role.enum';
+
 export class CreateOrganizationMemberDto {
+  @ApiProperty({ description: 'Organization the membership belongs to' })
+  @IsString()
+  @IsNotEmpty()
   organizationId!: string;
+
+  @ApiProperty({ description: 'User being granted membership' })
+  @IsString()
+  @IsNotEmpty()
   userId!: string;
-  role!: string;
+
+  @ApiProperty({ enum: OrganizationRole, example: OrganizationRole.MEMBER })
+  @IsEnum(OrganizationRole)
+  role!: OrganizationRole;
 }

--- a/src/organization-member/dto/update-organization-member.dto.ts
+++ b/src/organization-member/dto/update-organization-member.dto.ts
@@ -1,3 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { OrganizationRole } from '../../common/enums/organization-role.enum';
+
 export class UpdateOrganizationMemberDto {
-  role?: string;
+  @ApiProperty({
+    enum: OrganizationRole,
+    required: false,
+    example: OrganizationRole.ADMIN,
+  })
+  @IsEnum(OrganizationRole)
+  @IsOptional()
+  role?: OrganizationRole;
 }

--- a/src/organization-member/organization-member.controller.ts
+++ b/src/organization-member/organization-member.controller.ts
@@ -1,58 +1,111 @@
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ParseObjectIdPipe } from '../common/pipes/parse-object-id.pipe';
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { OrganizationMemberService } from './organization-member.service';
 import { CreateOrganizationMemberDto } from './dto/create-organization-member.dto';
 import { UpdateOrganizationMemberDto } from './dto/update-organization-member.dto';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
-import { RolesGuard } from '../common/guards/roles.guard';
+import { OrganizationRolesGuard } from '../common/guards/organization-roles.guard';
+import type { ResolvedOrgMembership } from '../common/guards/organization-roles.guard';
+import { OrganizationRole } from '../common/enums/organization-role.enum';
 import { Role } from '../common/enums/role.enum';
-import { Roles } from '../common/decorators/roles.decorator';
+import { OrgRoles, OrgScope } from '../common/decorators/org-roles.decorator';
+import { OrgMembership } from '../common/decorators/org-membership.decorator';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { AuditActor } from '../common/audit/audit-context';
+import type { AuditContext } from '../common/audit/audit-context';
 
 @ApiBearerAuth('access-token')
+@ApiTags('Organization Members')
 @Controller('organization-members')
+@UseGuards(JwtAuthGuard, OrganizationRolesGuard)
 export class OrganizationMemberController {
   constructor(private readonly service: OrganizationMemberService) {}
 
   @Get('organization/:orgId')
-  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'List members of an organization (members only)' })
+  @OrgScope({ source: 'param', key: 'orgId' })
+  @OrgRoles(
+    OrganizationRole.OWNER,
+    OrganizationRole.ADMIN,
+    OrganizationRole.INSTRUCTOR,
+    OrganizationRole.MEMBER,
+  )
   findByOrganization(@Param('orgId') orgId: string) {
     return this.service.findByOrganization(orgId);
   }
 
   @Get('user/:userId')
-  @UseGuards(JwtAuthGuard)
-  findByUser(@Param('userId') userId: string) {
-    return this.service.findByUser(userId);
+  @ApiOperation({ summary: 'List your own organization memberships' })
+  findByUser(
+    @Param('userId') userId: string,
+    @CurrentUser('sub') requesterId: string,
+    @CurrentUser('role') requesterRole: string,
+  ) {
+    return this.service.findByUser(
+      userId,
+      requesterId,
+      requesterRole === Role.ADMIN,
+    );
   }
 
   @Get(':id')
-  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get a membership (members of the same org only)' })
+  @OrgScope({ source: 'membershipParam', key: 'id' })
+  @OrgRoles(
+    OrganizationRole.OWNER,
+    OrganizationRole.ADMIN,
+    OrganizationRole.INSTRUCTOR,
+    OrganizationRole.MEMBER,
+  )
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ADMIN)
-  addMember(@Body() payload: CreateOrganizationMemberDto) {
-    return this.service.addMember(payload);
+  @ApiOperation({ summary: 'Add a member (organization owner or admin)' })
+  @OrgScope({ source: 'body', key: 'organizationId' })
+  @OrgRoles(OrganizationRole.OWNER, OrganizationRole.ADMIN)
+  addMember(
+    @Body() payload: CreateOrganizationMemberDto,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.addMember(payload, audit);
   }
 
   @Patch(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ADMIN)
+  @ApiOperation({
+    summary: 'Change a member role (organization owner or admin)',
+  })
+  @OrgScope({ source: 'membershipParam', key: 'id' })
+  @OrgRoles(OrganizationRole.OWNER, OrganizationRole.ADMIN)
   updateRole(
     @Param('id', new ParseObjectIdPipe()) id: string,
     @Body() payload: UpdateOrganizationMemberDto,
+    @OrgMembership() membership: ResolvedOrgMembership,
+    @AuditActor() audit: AuditContext,
   ) {
-    return this.service.updateRole(id, payload);
+    return this.service.updateRole(id, payload, membership?.role, audit);
   }
 
   @Delete(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ADMIN)
-  removeMember(@Param('id', new ParseObjectIdPipe()) id: string) {
-    return this.service.removeMember(id);
+  @ApiOperation({ summary: 'Remove a member (organization owner or admin)' })
+  @OrgScope({ source: 'membershipParam', key: 'id' })
+  @OrgRoles(OrganizationRole.OWNER, OrganizationRole.ADMIN)
+  removeMember(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @OrgMembership() membership: ResolvedOrgMembership,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.removeMember(id, membership?.role, audit);
   }
 }

--- a/src/organization-member/organization-member.module.ts
+++ b/src/organization-member/organization-member.module.ts
@@ -6,6 +6,7 @@ import {
   OrganizationMember,
   OrganizationMemberSchema,
 } from './schemas/organization-member.schema';
+import { OrganizationRolesGuard } from '../common/guards/organization-roles.guard';
 
 @Module({
   imports: [
@@ -14,7 +15,7 @@ import {
     ]),
   ],
   controllers: [OrganizationMemberController],
-  providers: [OrganizationMemberService],
+  providers: [OrganizationMemberService, OrganizationRolesGuard],
   exports: [OrganizationMemberService],
 })
 export class OrganizationMemberModule {}

--- a/src/organization-member/organization-member.service.spec.ts
+++ b/src/organization-member/organization-member.service.spec.ts
@@ -1,0 +1,270 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import { OrganizationMemberService } from './organization-member.service';
+import { OrganizationMember } from './schemas/organization-member.schema';
+import { OrganizationRole } from '../common/enums/organization-role.enum';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import { AuditContext } from '../common/audit/audit-context';
+
+const audit: AuditContext = {
+  actorId: 'u-owner',
+  actorEmail: 'owner@org.test',
+  actorRole: 'tutor',
+  requestId: 'req-1',
+  ip: '127.0.0.1',
+  userAgent: 'jest',
+};
+
+const auditService = { record: jest.fn().mockResolvedValue(null) };
+
+const memberDoc = (over: Record<string, unknown> = {}) => ({
+  id: 'm-1',
+  organizationId: 'org-a',
+  userId: 'u-member',
+  role: OrganizationRole.MEMBER,
+  toObject() {
+    const { toObject, ...rest } = this;
+    return rest;
+  },
+  ...over,
+});
+
+const mockModel: any = jest.fn();
+mockModel.findOne = jest.fn();
+mockModel.find = jest.fn();
+mockModel.findById = jest.fn();
+mockModel.findByIdAndUpdate = jest.fn();
+mockModel.findByIdAndDelete = jest.fn();
+mockModel.countDocuments = jest.fn();
+
+const exec = <T>(value: T) => ({ exec: jest.fn().mockResolvedValue(value) });
+
+describe('OrganizationMemberService', () => {
+  let service: OrganizationMemberService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    auditService.record.mockResolvedValue(null);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganizationMemberService,
+        {
+          provide: getModelToken(OrganizationMember.name),
+          useValue: mockModel,
+        },
+        { provide: AuditService, useValue: auditService },
+      ],
+    }).compile();
+
+    service = module.get(OrganizationMemberService);
+  });
+
+  describe('findByUser', () => {
+    it('lets a caller list their own memberships', async () => {
+      mockModel.find.mockReturnValue(exec([memberDoc()]));
+
+      await expect(service.findByUser('u-1', 'u-1')).resolves.toHaveLength(1);
+      expect(mockModel.find).toHaveBeenCalledWith({ userId: 'u-1' });
+    });
+
+    it("refuses to enumerate another user's memberships", async () => {
+      await expect(
+        service.findByUser('u-victim', 'u-attacker'),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockModel.find).not.toHaveBeenCalled();
+    });
+
+    it('allows a platform admin to list any user', async () => {
+      mockModel.find.mockReturnValue(exec([]));
+
+      await expect(
+        service.findByUser('u-victim', 'platform-admin', true),
+      ).resolves.toEqual([]);
+    });
+  });
+
+  describe('updateRole', () => {
+    it('records an audit entry with before and after roles', async () => {
+      mockModel.findById.mockReturnValue(exec(memberDoc()));
+      mockModel.findByIdAndUpdate.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.INSTRUCTOR })),
+      );
+
+      await service.updateRole(
+        'm-1',
+        { role: OrganizationRole.INSTRUCTOR },
+        OrganizationRole.ADMIN,
+        audit,
+      );
+
+      expect(auditService.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.ORGANIZATION_MEMBER_ROLE_CHANGED,
+          context: audit,
+          target: { type: 'organization_member', id: 'm-1' },
+          before: expect.objectContaining({ role: OrganizationRole.MEMBER }),
+          after: expect.objectContaining({ role: OrganizationRole.INSTRUCTOR }),
+        }),
+      );
+    });
+
+    it('refuses a missing role', async () => {
+      mockModel.findById.mockReturnValue(exec(memberDoc()));
+
+      await expect(
+        service.updateRole('m-1', {}, OrganizationRole.OWNER, audit),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('stops an org admin from granting ownership', async () => {
+      mockModel.findById.mockReturnValue(exec(memberDoc()));
+
+      await expect(
+        service.updateRole(
+          'm-1',
+          { role: OrganizationRole.OWNER },
+          OrganizationRole.ADMIN,
+          audit,
+        ),
+      ).rejects.toThrow(/Only an organization owner can grant or revoke/);
+      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('stops an org admin from demoting an owner', async () => {
+      mockModel.findById.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.OWNER })),
+      );
+
+      await expect(
+        service.updateRole(
+          'm-1',
+          { role: OrganizationRole.MEMBER },
+          OrganizationRole.ADMIN,
+          audit,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('lets an owner grant ownership to someone else', async () => {
+      mockModel.findById.mockReturnValue(exec(memberDoc()));
+      mockModel.findByIdAndUpdate.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.OWNER })),
+      );
+
+      await expect(
+        service.updateRole(
+          'm-1',
+          { role: OrganizationRole.OWNER },
+          OrganizationRole.OWNER,
+          audit,
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it('refuses to demote the last remaining owner', async () => {
+      mockModel.findById.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.OWNER })),
+      );
+      mockModel.countDocuments.mockReturnValue(exec(0));
+
+      await expect(
+        service.updateRole(
+          'm-1',
+          { role: OrganizationRole.ADMIN },
+          OrganizationRole.OWNER,
+          audit,
+        ),
+      ).rejects.toThrow(/at least one owner/);
+    });
+
+    it('allows demoting an owner when another owner remains', async () => {
+      mockModel.findById.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.OWNER })),
+      );
+      mockModel.countDocuments.mockReturnValue(exec(1));
+      mockModel.findByIdAndUpdate.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.ADMIN })),
+      );
+
+      await expect(
+        service.updateRole(
+          'm-1',
+          { role: OrganizationRole.ADMIN },
+          OrganizationRole.OWNER,
+          audit,
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it('surfaces a missing membership as 404', async () => {
+      mockModel.findById.mockReturnValue(exec(null));
+
+      await expect(
+        service.updateRole('nope', { role: OrganizationRole.MEMBER }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('removeMember', () => {
+    it('audits the removal with the prior state', async () => {
+      mockModel.findById.mockReturnValue(exec(memberDoc()));
+      mockModel.findByIdAndDelete.mockReturnValue(exec(memberDoc()));
+
+      await service.removeMember('m-1', OrganizationRole.ADMIN, audit);
+
+      expect(auditService.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: AuditAction.ORGANIZATION_MEMBER_REMOVED,
+          before: expect.objectContaining({ userId: 'u-member' }),
+          after: null,
+        }),
+      );
+    });
+
+    it('stops an org admin from removing an owner', async () => {
+      mockModel.findById.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.OWNER })),
+      );
+
+      await expect(
+        service.removeMember('m-1', OrganizationRole.ADMIN, audit),
+      ).rejects.toThrow(/Only an organization owner can remove another owner/);
+      expect(mockModel.findByIdAndDelete).not.toHaveBeenCalled();
+    });
+
+    it('refuses to remove the last owner', async () => {
+      mockModel.findById.mockReturnValue(
+        exec(memberDoc({ role: OrganizationRole.OWNER })),
+      );
+      mockModel.countDocuments.mockReturnValue(exec(0));
+
+      await expect(
+        service.removeMember('m-1', OrganizationRole.OWNER, audit),
+      ).rejects.toThrow(/at least one owner/);
+    });
+  });
+
+  describe('addMember', () => {
+    it('rejects a duplicate membership', async () => {
+      mockModel.findOne.mockReturnValue(exec(memberDoc()));
+
+      await expect(
+        service.addMember(
+          {
+            organizationId: 'org-a',
+            userId: 'u-member',
+            role: OrganizationRole.MEMBER,
+          },
+          audit,
+        ),
+      ).rejects.toThrow(/already a member/);
+    });
+  });
+});

--- a/src/organization-member/organization-member.service.ts
+++ b/src/organization-member/organization-member.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CreateOrganizationMemberDto } from './dto/create-organization-member.dto';
@@ -7,16 +13,29 @@ import {
   OrganizationMember,
   OrganizationMemberDocument,
 } from './schemas/organization-member.schema';
+import { OrganizationRole } from '../common/enums/organization-role.enum';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import {
+  AuditContext,
+  systemAuditContext,
+} from '../common/audit/audit-context';
+import { snapshot } from '../common/audit/audit-redaction';
+
+const TARGET_TYPE = 'organization_member';
+const MEMBER_AUDIT_FIELDS = ['organizationId', 'userId', 'role'] as const;
 
 @Injectable()
 export class OrganizationMemberService {
   constructor(
     @InjectModel(OrganizationMember.name)
     private readonly memberModel: Model<OrganizationMemberDocument>,
+    private readonly auditService: AuditService,
   ) {}
 
   async addMember(
     payload: CreateOrganizationMemberDto,
+    audit?: AuditContext,
   ): Promise<OrganizationMember> {
     const existing = await this.memberModel
       .findOne({
@@ -30,8 +49,17 @@ export class OrganizationMemberService {
       );
     }
 
-    const member = new this.memberModel(payload);
-    return member.save();
+    const member = await new this.memberModel(payload).save();
+
+    await this.auditService.record({
+      action: AuditAction.ORGANIZATION_MEMBER_ADDED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id: member.id },
+      before: null,
+      after: snapshot(member, MEMBER_AUDIT_FIELDS),
+    });
+
+    return member;
   }
 
   async findByOrganization(
@@ -40,7 +68,21 @@ export class OrganizationMemberService {
     return this.memberModel.find({ organizationId }).exec();
   }
 
-  async findByUser(userId: string): Promise<OrganizationMember[]> {
+  /**
+   * Memberships for a user. Callers may only read their own memberships unless
+   * `requesterIsPlatformAdmin` — otherwise any authenticated user could
+   * enumerate which organizations another user belongs to.
+   */
+  async findByUser(
+    userId: string,
+    requesterId: string,
+    requesterIsPlatformAdmin = false,
+  ): Promise<OrganizationMember[]> {
+    if (!requesterIsPlatformAdmin && userId !== requesterId) {
+      throw new ForbiddenException(
+        'You may only list your own organization memberships',
+      );
+    }
     return this.memberModel.find({ userId }).exec();
   }
 
@@ -52,24 +94,115 @@ export class OrganizationMemberService {
     return member;
   }
 
+  /**
+   * Changes a membership role.
+   *
+   * `owner` is handled specially: only an existing owner may grant or revoke
+   * it, and the last remaining owner cannot be demoted, so an organization is
+   * never left without an administrator.
+   */
   async updateRole(
     id: string,
     payload: UpdateOrganizationMemberDto,
+    actorRole?: OrganizationRole,
+    audit?: AuditContext,
   ): Promise<OrganizationMember> {
+    const existing = await this.findOne(id);
+    const before = snapshot(existing, MEMBER_AUDIT_FIELDS);
+
+    const nextRole = payload.role;
+    if (!nextRole) {
+      throw new BadRequestException('A role is required');
+    }
+
+    const touchesOwnership =
+      nextRole === OrganizationRole.OWNER ||
+      existing.role === OrganizationRole.OWNER;
+
+    if (touchesOwnership && actorRole && actorRole !== OrganizationRole.OWNER) {
+      throw new ForbiddenException(
+        'Only an organization owner can grant or revoke the owner role',
+      );
+    }
+
+    if (
+      existing.role === OrganizationRole.OWNER &&
+      nextRole !== OrganizationRole.OWNER
+    ) {
+      await this.assertNotLastOwner(existing.organizationId, id);
+    }
+
     const member = await this.memberModel
-      .findByIdAndUpdate(id, { role: payload.role }, { new: true })
+      .findByIdAndUpdate(id, { role: nextRole }, { new: true })
       .exec();
     if (!member) {
       throw new NotFoundException('Organization member not found');
     }
+
+    await this.auditService.record({
+      action: AuditAction.ORGANIZATION_MEMBER_ROLE_CHANGED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before,
+      after: snapshot(member, MEMBER_AUDIT_FIELDS),
+    });
+
     return member;
   }
 
-  async removeMember(id: string): Promise<{ id: string; deleted: boolean }> {
+  async removeMember(
+    id: string,
+    actorRole?: OrganizationRole,
+    audit?: AuditContext,
+  ): Promise<{ id: string; deleted: boolean }> {
+    const existing = await this.findOne(id);
+
+    if (
+      existing.role === OrganizationRole.OWNER &&
+      actorRole &&
+      actorRole !== OrganizationRole.OWNER
+    ) {
+      throw new ForbiddenException(
+        'Only an organization owner can remove another owner',
+      );
+    }
+
+    if (existing.role === OrganizationRole.OWNER) {
+      await this.assertNotLastOwner(existing.organizationId, id);
+    }
+
     const result = await this.memberModel.findByIdAndDelete(id).exec();
     if (!result) {
       throw new NotFoundException('Organization member not found');
     }
+
+    await this.auditService.record({
+      action: AuditAction.ORGANIZATION_MEMBER_REMOVED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before: snapshot(result, MEMBER_AUDIT_FIELDS),
+      after: null,
+    });
+
     return { id, deleted: true };
+  }
+
+  private async assertNotLastOwner(
+    organizationId: string,
+    excludeMembershipId: string,
+  ): Promise<void> {
+    const remainingOwners = await this.memberModel
+      .countDocuments({
+        organizationId,
+        role: OrganizationRole.OWNER,
+        _id: { $ne: excludeMembershipId },
+      })
+      .exec();
+
+    if (remainingOwners === 0) {
+      throw new BadRequestException(
+        'An organization must retain at least one owner',
+      );
+    }
   }
 }

--- a/src/organization-member/schemas/organization-member.schema.ts
+++ b/src/organization-member/schemas/organization-member.schema.ts
@@ -1,19 +1,33 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
 import { applySoftDeleteSchema } from '../../common/soft-delete/soft-delete.schema';
+import {
+  ORGANIZATION_ROLE_HIERARCHY,
+  OrganizationRole,
+} from '../../common/enums/organization-role.enum';
 
 export type OrganizationMemberDocument = HydratedDocument<OrganizationMember>;
 
 @Schema({ timestamps: true })
 export class OrganizationMember {
-  @Prop({ required: true })
+  @Prop({ required: true, index: true })
   organizationId: string;
 
-  @Prop({ required: true })
+  @Prop({ required: true, index: true })
   userId: string;
 
-  @Prop({ required: true })
-  role: string;
+  /**
+   * Organization-scoped role. Constrained to {@link OrganizationRole} so a
+   * membership can never carry an unrecognised value that the authorization
+   * guard would then have to interpret.
+   */
+  @Prop({
+    type: String,
+    required: true,
+    enum: ORGANIZATION_ROLE_HIERARCHY,
+    default: OrganizationRole.MEMBER,
+  })
+  role: OrganizationRole;
 
   @Prop({ type: Date, default: null })
   deletedAt?: Date | null;

--- a/src/organization/dto/create-organization.dto.ts
+++ b/src/organization/dto/create-organization.dto.ts
@@ -1,7 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
+
 export class CreateOrganizationDto {
+  @ApiProperty({ example: 'ChainVerse Academy' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
   name!: string;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
   description?: string;
+
+  @ApiProperty({ required: false, example: 'https://example.com' })
+  @IsUrl()
+  @IsOptional()
   website?: string;
+
+  @ApiProperty({ required: false, example: 'https://example.com/logo.png' })
+  @IsUrl()
+  @IsOptional()
   logoUrl?: string;
+
+  @ApiProperty({ required: false, type: Object })
+  @IsObject()
+  @IsOptional()
   metadata?: Record<string, unknown>;
 }

--- a/src/organization/dto/update-organization.dto.ts
+++ b/src/organization/dto/update-organization.dto.ts
@@ -1,7 +1,4 @@
-export class UpdateOrganizationDto {
-  name?: string;
-  description?: string;
-  website?: string;
-  logoUrl?: string;
-  metadata?: Record<string, unknown>;
-}
+import { PartialType } from '@nestjs/swagger';
+import { CreateOrganizationDto } from './create-organization.dto';
+
+export class UpdateOrganizationDto extends PartialType(CreateOrganizationDto) {}

--- a/src/organization/organization.controller.ts
+++ b/src/organization/organization.controller.ts
@@ -1,50 +1,84 @@
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ParseObjectIdPipe } from '../common/pipes/parse-object-id.pipe';
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { OrganizationService } from './organization.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
 import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
-import { RolesGuard } from '../common/guards/roles.guard';
-import { Role } from '../common/enums/role.enum';
-import { Roles } from '../common/decorators/roles.decorator';
+import { OrganizationRolesGuard } from '../common/guards/organization-roles.guard';
+import { OrganizationRole } from '../common/enums/organization-role.enum';
+import { OrgRoles, OrgScope } from '../common/decorators/org-roles.decorator';
 import { Public } from '../common/decorators/public.decorator';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { AuditActor } from '../common/audit/audit-context';
+import type { AuditContext } from '../common/audit/audit-context';
 
 @ApiBearerAuth('access-token')
+@ApiTags('Organizations')
 @Controller('organizations')
 export class OrganizationController {
   constructor(private readonly service: OrganizationService) {}
 
   @Public()
   @Get()
+  @ApiOperation({ summary: 'List organizations (public directory)' })
   findAll() {
     return this.service.findAll();
   }
 
   @Public()
   @Get(':id')
+  @ApiOperation({ summary: 'Get an organization profile (public)' })
   findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
     return this.service.findOne(id);
   }
 
+  /**
+   * Creating an organization needs no prior membership — the creator is
+   * enrolled as its `owner`, which is what every later org-scoped check reads.
+   */
   @Post()
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ADMIN)
-  create(@Body() payload: CreateOrganizationDto) {
-    return this.service.create(payload);
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Create an organization (creator becomes owner)' })
+  create(
+    @Body() payload: CreateOrganizationDto,
+    @CurrentUser('sub') creatorId: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.create(payload, creatorId, audit);
   }
 
   @Patch(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ADMIN)
-  update(@Param('id', new ParseObjectIdPipe()) id: string, @Body() payload: UpdateOrganizationDto) {
-    return this.service.update(id, payload);
+  @UseGuards(JwtAuthGuard, OrganizationRolesGuard)
+  @OrgScope({ source: 'param', key: 'id' })
+  @OrgRoles(OrganizationRole.OWNER, OrganizationRole.ADMIN)
+  @ApiOperation({ summary: 'Update an organization (owner or org admin)' })
+  update(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @Body() payload: UpdateOrganizationDto,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.update(id, payload, audit);
   }
 
   @Delete(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ADMIN)
-  remove(@Param('id', new ParseObjectIdPipe()) id: string) {
-    return this.service.remove(id);
+  @UseGuards(JwtAuthGuard, OrganizationRolesGuard)
+  @OrgScope({ source: 'param', key: 'id' })
+  @OrgRoles(OrganizationRole.OWNER)
+  @ApiOperation({ summary: 'Delete an organization (owner only)' })
+  remove(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.remove(id, audit);
   }
 }

--- a/src/organization/organization.module.ts
+++ b/src/organization/organization.module.ts
@@ -6,15 +6,23 @@ import {
   Organization,
   OrganizationSchema,
 } from './schemas/organization.schema';
+import {
+  OrganizationMember,
+  OrganizationMemberSchema,
+} from '../organization-member/schemas/organization-member.schema';
+import { OrganizationRolesGuard } from '../common/guards/organization-roles.guard';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Organization.name, schema: OrganizationSchema },
+      // Registered here too: the org service seeds the owner membership and
+      // OrganizationRolesGuard resolves memberships from this model.
+      { name: OrganizationMember.name, schema: OrganizationMemberSchema },
     ]),
   ],
   controllers: [OrganizationController],
-  providers: [OrganizationService],
+  providers: [OrganizationService, OrganizationRolesGuard],
   exports: [OrganizationService],
 })
 export class OrganizationModule {}

--- a/src/organization/organization.service.ts
+++ b/src/organization/organization.service.ts
@@ -7,17 +7,69 @@ import {
   Organization,
   OrganizationDocument,
 } from './schemas/organization.schema';
+import {
+  OrganizationMember,
+  OrganizationMemberDocument,
+} from '../organization-member/schemas/organization-member.schema';
+import { OrganizationRole } from '../common/enums/organization-role.enum';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import {
+  AuditContext,
+  systemAuditContext,
+} from '../common/audit/audit-context';
+import { snapshot } from '../common/audit/audit-redaction';
+
+const TARGET_TYPE = 'organization';
+const ORG_AUDIT_FIELDS = [
+  'name',
+  'description',
+  'website',
+  'logoUrl',
+  'metadata',
+] as const;
 
 @Injectable()
 export class OrganizationService {
   constructor(
     @InjectModel(Organization.name)
     private readonly organizationModel: Model<OrganizationDocument>,
+    @InjectModel(OrganizationMember.name)
+    private readonly memberModel: Model<OrganizationMemberDocument>,
+    private readonly auditService: AuditService,
   ) {}
 
-  async create(payload: CreateOrganizationDto): Promise<Organization> {
-    const organization = new this.organizationModel(payload);
-    return organization.save();
+  /**
+   * Creates an organization and seeds its first membership.
+   *
+   * The creator becomes `owner` so the organization is never left without an
+   * administrator and subsequent org-scoped checks have a principal to match.
+   */
+  async create(
+    payload: CreateOrganizationDto,
+    creatorUserId?: string,
+    audit?: AuditContext,
+  ): Promise<Organization> {
+    const organization = await new this.organizationModel(payload).save();
+
+    const ownerId = creatorUserId ?? audit?.actorId;
+    if (ownerId && ownerId !== 'anonymous') {
+      await new this.memberModel({
+        organizationId: organization.id,
+        userId: ownerId,
+        role: OrganizationRole.OWNER,
+      }).save();
+    }
+
+    await this.auditService.record({
+      action: AuditAction.ORGANIZATION_CREATED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id: organization.id },
+      before: null,
+      after: snapshot(organization, ORG_AUDIT_FIELDS),
+    });
+
+    return organization;
   }
 
   async findAll(): Promise<Organization[]> {
@@ -35,21 +87,50 @@ export class OrganizationService {
   async update(
     id: string,
     payload: UpdateOrganizationDto,
+    audit?: AuditContext,
   ): Promise<Organization> {
+    const existing = await this.findOne(id);
+    const before = snapshot(existing, ORG_AUDIT_FIELDS);
+
     const org = await this.organizationModel
       .findByIdAndUpdate(id, payload, { new: true })
       .exec();
     if (!org) {
       throw new NotFoundException('Organization not found');
     }
+
+    await this.auditService.record({
+      action: AuditAction.ORGANIZATION_UPDATED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before,
+      after: snapshot(org, ORG_AUDIT_FIELDS),
+    });
+
     return org;
   }
 
-  async remove(id: string): Promise<{ id: string; deleted: boolean }> {
+  async remove(
+    id: string,
+    audit?: AuditContext,
+  ): Promise<{ id: string; deleted: boolean }> {
     const result = await this.organizationModel.findByIdAndDelete(id).exec();
     if (!result) {
       throw new NotFoundException('Organization not found');
     }
+
+    // Memberships are meaningless once the organization is gone, and leaving
+    // them behind would let a recreated id inherit stale grants.
+    await this.memberModel.deleteMany({ organizationId: id }).exec();
+
+    await this.auditService.record({
+      action: AuditAction.ORGANIZATION_DELETED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before: snapshot(result, ORG_AUDIT_FIELDS),
+      after: null,
+    });
+
     return { id, deleted: true };
   }
 }

--- a/src/report-abuse/report-abuse.controller.ts
+++ b/src/report-abuse/report-abuse.controller.ts
@@ -1,6 +1,16 @@
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ParseObjectIdPipe } from '../common/pipes/parse-object-id.pipe';
-import { Body, Controller, Delete, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { ReportAbuseService } from './report-abuse.service';
 import { CreateReportAbuseDto } from './dto/create-report-abuse.dto';
 import { UpdateReportAbuseDto } from './dto/update-report-abuse.dto';
@@ -8,6 +18,8 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { AuditActor } from '../common/audit/audit-context';
+import type { AuditContext } from '../common/audit/audit-context';
 
 @ApiBearerAuth('access-token')
 @Controller('report-abuse')
@@ -47,14 +59,21 @@ export class ReportAbuseController {
   @Patch(':id')
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR)
-  update(@Param('id', new ParseObjectIdPipe()) id: string, @Body() payload: UpdateReportAbuseDto) {
-    return this.service.update(id, payload);
+  update(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @Body() payload: UpdateReportAbuseDto,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.update(id, payload, audit);
   }
 
   @Delete(':id')
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN)
-  remove(@Param('id', new ParseObjectIdPipe()) id: string) {
-    return this.service.remove(id);
+  remove(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.service.remove(id, audit);
   }
 }

--- a/src/report-abuse/report-abuse.service.spec.ts
+++ b/src/report-abuse/report-abuse.service.spec.ts
@@ -1,0 +1,141 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import { ReportAbuseService } from './report-abuse.service';
+import { AbuseReport } from './schemas/report-abuse.schema';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import { AuditContext } from '../common/audit/audit-context';
+
+const audit: AuditContext = {
+  actorId: 'mod-1',
+  actorEmail: 'mod@chainverse.io',
+  actorRole: 'moderator',
+  requestId: 'req-mod-1',
+  ip: '10.0.0.2',
+  userAgent: 'jest',
+};
+
+const auditService = { record: jest.fn().mockResolvedValue(null) };
+const entryFor = (action: AuditAction) =>
+  auditService.record.mock.calls
+    .map(([entry]) => entry)
+    .find((entry) => entry.action === action);
+
+const report = (over: Record<string, unknown> = {}) => ({
+  id: 'r-1',
+  reporterUserId: 'student-9',
+  reason: 'spam',
+  contentId: 'c-1',
+  contentType: 'course',
+  status: 'pending',
+  adminNotes: undefined,
+  toObject() {
+    const { toObject, ...rest } = this;
+    return rest;
+  },
+  ...over,
+});
+
+const exec = <T>(value: T) => ({ exec: jest.fn().mockResolvedValue(value) });
+
+const mockModel: any = jest.fn();
+mockModel.findById = jest.fn();
+mockModel.findByIdAndUpdate = jest.fn();
+mockModel.findByIdAndDelete = jest.fn();
+mockModel.find = jest.fn();
+
+describe('ReportAbuseService moderation auditing', () => {
+  let service: ReportAbuseService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportAbuseService,
+        { provide: getModelToken(AbuseReport.name), useValue: mockModel },
+        { provide: AuditService, useValue: auditService },
+      ],
+    }).compile();
+
+    service = module.get(ReportAbuseService);
+  });
+
+  describe('update', () => {
+    it('captures the status transition in before/after', async () => {
+      mockModel.findById.mockReturnValue(exec(report()));
+      mockModel.findByIdAndUpdate.mockReturnValue(
+        exec(report({ status: 'resolved', adminNotes: 'handled' })),
+      );
+
+      await service.update('r-1', { status: 'resolved' }, audit);
+
+      const entry = entryFor(AuditAction.ABUSE_REPORT_UPDATED);
+      expect(entry.context).toBe(audit);
+      expect(entry.target).toEqual({ type: 'abuse_report', id: 'r-1' });
+      expect(entry.before).toEqual(
+        expect.objectContaining({ status: 'pending' }),
+      );
+      expect(entry.after).toEqual(
+        expect.objectContaining({ status: 'resolved', adminNotes: 'handled' }),
+      );
+    });
+
+    it('reads the report before writing so the before snapshot is real', async () => {
+      mockModel.findById.mockReturnValue(exec(report()));
+      mockModel.findByIdAndUpdate.mockReturnValue(
+        exec(report({ status: 'resolved' })),
+      );
+
+      await service.update('r-1', { status: 'resolved' }, audit);
+
+      expect(mockModel.findById).toHaveBeenCalledWith('r-1');
+    });
+
+    it('does not audit an update to a report that does not exist', async () => {
+      mockModel.findById.mockReturnValue(exec(null));
+
+      await expect(
+        service.update('missing', { status: 'resolved' }, audit),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(auditService.record).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('audits the deletion with the prior state', async () => {
+      mockModel.findByIdAndDelete.mockReturnValue(exec(report()));
+
+      await service.remove('r-1', audit);
+
+      const entry = entryFor(AuditAction.ABUSE_REPORT_DELETED);
+      expect(entry.before).toEqual(
+        expect.objectContaining({ contentId: 'c-1', status: 'pending' }),
+      );
+      expect(entry.after).toBeNull();
+    });
+
+    it('masks the reporter address in the snapshot', async () => {
+      mockModel.findByIdAndDelete.mockReturnValue(
+        exec(report({ reporterUserId: 'reporter@chainverse.io' })),
+      );
+
+      await service.remove('r-1', audit);
+
+      const entry = entryFor(AuditAction.ABUSE_REPORT_DELETED);
+      expect(entry.before.reporterUserId).toBe('r*******@chainverse.io');
+    });
+
+    it('does not audit a deletion that never happened', async () => {
+      mockModel.findByIdAndDelete.mockReturnValue(exec(null));
+
+      await expect(service.remove('missing', audit)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(auditService.record).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/report-abuse/report-abuse.service.ts
+++ b/src/report-abuse/report-abuse.service.ts
@@ -7,12 +7,32 @@ import {
   AbuseReport,
   AbuseReportDocument,
 } from './schemas/report-abuse.schema';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction } from '../common/audit/audit-action.enum';
+import {
+  AuditContext,
+  systemAuditContext,
+} from '../common/audit/audit-context';
+import { snapshot } from '../common/audit/audit-redaction';
+
+const TARGET_TYPE = 'abuse_report';
+
+/** Fields captured in moderation audit snapshots. */
+const REPORT_AUDIT_FIELDS = [
+  'status',
+  'adminNotes',
+  'reason',
+  'contentId',
+  'contentType',
+  'reporterUserId',
+] as const;
 
 @Injectable()
 export class ReportAbuseService {
   constructor(
     @InjectModel(AbuseReport.name)
     private readonly abuseReportModel: Model<AbuseReportDocument>,
+    private readonly auditService: AuditService,
   ) {}
 
   async create(
@@ -42,21 +62,50 @@ export class ReportAbuseService {
   async update(
     id: string,
     payload: UpdateReportAbuseDto,
+    audit?: AuditContext,
   ): Promise<AbuseReport> {
+    // Read first so the audit entry can carry a genuine "before" snapshot.
+    const existing = await this.abuseReportModel.findById(id).exec();
+    if (!existing) {
+      throw new NotFoundException('Abuse report not found');
+    }
+    const before = snapshot(existing, REPORT_AUDIT_FIELDS);
+
     const report = await this.abuseReportModel
       .findByIdAndUpdate(id, payload, { new: true })
       .exec();
     if (!report) {
       throw new NotFoundException('Abuse report not found');
     }
+
+    await this.auditService.record({
+      action: AuditAction.ABUSE_REPORT_UPDATED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before,
+      after: snapshot(report, REPORT_AUDIT_FIELDS),
+    });
+
     return report;
   }
 
-  async remove(id: string): Promise<{ id: string; deleted: boolean }> {
+  async remove(
+    id: string,
+    audit?: AuditContext,
+  ): Promise<{ id: string; deleted: boolean }> {
     const result = await this.abuseReportModel.findByIdAndDelete(id).exec();
     if (!result) {
       throw new NotFoundException('Abuse report not found');
     }
+
+    await this.auditService.record({
+      action: AuditAction.ABUSE_REPORT_DELETED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id },
+      before: snapshot(result, REPORT_AUDIT_FIELDS),
+      after: null,
+    });
+
     return { id, deleted: true };
   }
 }

--- a/src/student-enrollment/schemas/enrollment.schema.ts
+++ b/src/student-enrollment/schemas/enrollment.schema.ts
@@ -10,7 +10,8 @@ class LessonProgress {
   @Prop({ default: false })
   completed: boolean;
 
-  @Prop({ default: null })
+  // `Date | null` is ambiguous to the metadata reflector, so the type is explicit.
+  @Prop({ type: Date, default: null })
   completedAt: Date | null;
 }
 

--- a/src/worker/dto/upload-worker-file.dto.ts
+++ b/src/worker/dto/upload-worker-file.dto.ts
@@ -1,5 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
 export class UploadWorkerFileDto {
+  @ApiProperty({ required: false, maxLength: 200 })
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
   title?: string;
+
+  @ApiProperty({ required: false, maxLength: 2000 })
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
   description?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Comma-separated tags',
+    maxLength: 500,
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
   tags?: string;
 }

--- a/src/worker/file-storage.service.spec.ts
+++ b/src/worker/file-storage.service.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileStorageService, StorageArea } from './file-storage.service';
+
+describe('FileStorageService', () => {
+  let service: FileStorageService;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'chainverse-uploads-'));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FileStorageService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => (key === 'uploads.root' ? root : undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(FileStorageService);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  describe('storeInQuarantine', () => {
+    it('writes new uploads into the quarantine area, not the clean one', async () => {
+      const stored = await service.storeInQuarantine(
+        Buffer.from('%PDF-1.7\n'),
+        '.pdf',
+      );
+
+      expect(stored.area).toBe(StorageArea.QUARANTINE);
+      expect(stored.absolutePath).toContain(`${StorageArea.QUARANTINE}/`);
+      expect(stored.absolutePath).not.toContain(`${StorageArea.CLEAN}/`);
+      await expect(readFile(stored.absolutePath, 'utf8')).resolves.toBe(
+        '%PDF-1.7\n',
+      );
+    });
+
+    it('generates a random storage key rather than reusing any caller input', async () => {
+      const a = await service.storeInQuarantine(Buffer.from('a'), '.pdf');
+      const b = await service.storeInQuarantine(Buffer.from('b'), '.pdf');
+
+      expect(a.storageKey).not.toBe(b.storageKey);
+      expect(a.storageKey).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.pdf$/,
+      );
+    });
+
+    it('records the sha256 and size of the stored bytes', async () => {
+      const stored = await service.storeInQuarantine(
+        Buffer.from('abc'),
+        '.pdf',
+      );
+
+      expect(stored.size).toBe(3);
+      // sha256("abc")
+      expect(stored.sha256).toBe(
+        'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+      );
+    });
+
+    it('falls back to .bin for a suspicious extension', async () => {
+      const stored = await service.storeInQuarantine(
+        Buffer.from('x'),
+        '.php.pdf/../..',
+      );
+
+      expect(stored.storageKey.endsWith('.bin')).toBe(true);
+    });
+
+    it('writes files owner-readable only', async () => {
+      const stored = await service.storeInQuarantine(Buffer.from('x'), '.pdf');
+      const stats = await stat(stored.absolutePath);
+
+      expect(stats.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  describe('move', () => {
+    it('promotes a scanned file from quarantine to clean', async () => {
+      const stored = await service.storeInQuarantine(Buffer.from('ok'), '.pdf');
+
+      const target = await service.move(
+        stored.storageKey,
+        StorageArea.QUARANTINE,
+        StorageArea.CLEAN,
+      );
+
+      expect(target).toContain(`${StorageArea.CLEAN}/`);
+      await expect(
+        service.exists(stored.storageKey, StorageArea.CLEAN),
+      ).resolves.toBe(true);
+      await expect(
+        service.exists(stored.storageKey, StorageArea.QUARANTINE),
+      ).resolves.toBe(false);
+    });
+
+    it('quarantines a detection under the infected area', async () => {
+      const stored = await service.storeInQuarantine(
+        Buffer.from('bad'),
+        '.pdf',
+      );
+
+      await service.move(
+        stored.storageKey,
+        StorageArea.QUARANTINE,
+        StorageArea.INFECTED,
+      );
+
+      await expect(
+        service.exists(stored.storageKey, StorageArea.INFECTED),
+      ).resolves.toBe(true);
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes the stored bytes', async () => {
+      const stored = await service.storeInQuarantine(Buffer.from('x'), '.pdf');
+
+      await service.remove(stored.storageKey, StorageArea.QUARANTINE);
+
+      await expect(
+        service.exists(stored.storageKey, StorageArea.QUARANTINE),
+      ).resolves.toBe(false);
+    });
+
+    it('is a no-op for a file that is already gone', async () => {
+      await expect(
+        service.remove('never-existed.pdf', StorageArea.QUARANTINE),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('resolveWithin', () => {
+    it('resolves an ordinary key inside its area', () => {
+      expect(service.resolveWithin(StorageArea.CLEAN, 'file.pdf')).toBe(
+        join(root, StorageArea.CLEAN, 'file.pdf'),
+      );
+    });
+
+    it.each(['../quarantine/secret.pdf', '../../../etc/passwd', '/etc/passwd'])(
+      'refuses a key escaping the area: %s',
+      (key) => {
+        expect(() => service.resolveWithin(StorageArea.CLEAN, key)).toThrow(
+          /outside/,
+        );
+      },
+    );
+  });
+
+  describe('root', () => {
+    it('defaults outside the served tree', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FileStorageService,
+          { provide: ConfigService, useValue: { get: () => undefined } },
+        ],
+      }).compile();
+
+      const defaulted = module.get(FileStorageService);
+
+      expect(defaulted.root).toContain('var/uploads');
+    });
+  });
+});

--- a/src/worker/file-storage.service.ts
+++ b/src/worker/file-storage.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createReadStream, ReadStream } from 'node:fs';
+import { mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { isAbsolute, join, resolve, sep } from 'node:path';
+import * as crypto from 'node:crypto';
+
+/** Sub-directories of the upload root, none of which is web-served. */
+export enum StorageArea {
+  QUARANTINE = 'quarantine',
+  CLEAN = 'clean',
+  INFECTED = 'infected',
+}
+
+export interface StoredFile {
+  /** Opaque storage key; never derived from caller input. */
+  storageKey: string;
+  area: StorageArea;
+  absolutePath: string;
+  size: number;
+  sha256: string;
+}
+
+/**
+ * Owns every byte written by the upload pipeline.
+ *
+ * Two properties matter here:
+ *  - Storage names are generated (`randomUUID`), so a caller can never
+ *    influence a path, and collisions or overwrites are not possible.
+ *  - The root defaults to `var/uploads`, deliberately outside any directory the
+ *    application serves, and files land in `quarantine/` first. Nothing reaches
+ *    `clean/` until a scan says so.
+ */
+@Injectable()
+export class FileStorageService {
+  private readonly logger = new Logger(FileStorageService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  /** Absolute path of the upload root. */
+  get root(): string {
+    const configured =
+      this.configService.get<string>('uploads.root') ?? 'var/uploads';
+    return isAbsolute(configured)
+      ? configured
+      : resolve(process.cwd(), configured);
+  }
+
+  areaPath(area: StorageArea): string {
+    return join(this.root, area);
+  }
+
+  /**
+   * Writes a validated buffer into quarantine under a freshly generated key.
+   * Mode 0600 keeps the bytes unreadable to other local users.
+   */
+  async storeInQuarantine(
+    buffer: Buffer,
+    extension: string,
+  ): Promise<StoredFile> {
+    const safeExtension = /^\.[A-Za-z0-9]{1,10}$/.test(extension)
+      ? extension.toLowerCase()
+      : '.bin';
+    const storageKey = `${crypto.randomUUID()}${safeExtension}`;
+
+    const directory = this.areaPath(StorageArea.QUARANTINE);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+
+    const absolutePath = this.resolveWithin(StorageArea.QUARANTINE, storageKey);
+    await writeFile(absolutePath, buffer, { mode: 0o600, flag: 'wx' });
+
+    return {
+      storageKey,
+      area: StorageArea.QUARANTINE,
+      absolutePath,
+      size: buffer.length,
+      sha256: crypto.createHash('sha256').update(buffer).digest('hex'),
+    };
+  }
+
+  /** Moves a stored file between areas (quarantine → clean / infected). */
+  async move(
+    storageKey: string,
+    from: StorageArea,
+    to: StorageArea,
+  ): Promise<string> {
+    const source = this.resolveWithin(from, storageKey);
+    const targetDirectory = this.areaPath(to);
+    await mkdir(targetDirectory, { recursive: true, mode: 0o700 });
+
+    const target = this.resolveWithin(to, storageKey);
+    await rename(source, target);
+    return target;
+  }
+
+  async remove(storageKey: string, area: StorageArea): Promise<void> {
+    try {
+      await rm(this.resolveWithin(area, storageKey), { force: true });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(
+        `Failed to remove ${area}/${storageKey} from upload storage: ${message}`,
+      );
+    }
+  }
+
+  async exists(storageKey: string, area: StorageArea): Promise<boolean> {
+    try {
+      await stat(this.resolveWithin(area, storageKey));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  createReadStream(storageKey: string, area: StorageArea): ReadStream {
+    return createReadStream(this.resolveWithin(area, storageKey));
+  }
+
+  /**
+   * Resolves `storageKey` inside `area` and refuses anything that escapes it.
+   *
+   * Keys are generated internally, so this should never trip — it is a
+   * backstop against a future caller passing through a user-supplied key.
+   */
+  resolveWithin(area: StorageArea, storageKey: string): string {
+    const areaRoot = this.areaPath(area);
+    const candidate = resolve(areaRoot, storageKey);
+
+    if (candidate !== areaRoot && !candidate.startsWith(areaRoot + sep)) {
+      throw new Error(`Refusing to access path outside ${area}: ${storageKey}`);
+    }
+    return candidate;
+  }
+}

--- a/src/worker/file-validation.spec.ts
+++ b/src/worker/file-validation.spec.ts
@@ -1,0 +1,172 @@
+import {
+  hasSignature,
+  sanitizeOriginalName,
+  validateUploadedFile,
+} from './file-validation';
+
+const PDF = Buffer.concat([
+  Buffer.from('%PDF-1.7\n'),
+  Buffer.from('some document body'),
+]);
+const PNG = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.alloc(32),
+]);
+const JPEG = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.alloc(32),
+]);
+
+describe('sanitizeOriginalName', () => {
+  it('strips POSIX directory traversal', () => {
+    expect(sanitizeOriginalName('../../etc/passwd')).toBe('passwd');
+  });
+
+  it('strips Windows directory traversal', () => {
+    expect(sanitizeOriginalName('..\\..\\windows\\system32\\cmd.exe')).toBe(
+      'cmd.exe',
+    );
+  });
+
+  it('removes leading dots so no dotfile can be produced', () => {
+    expect(sanitizeOriginalName('...hidden.pdf')).toBe('hidden.pdf');
+  });
+
+  it('replaces characters outside the safe set', () => {
+    expect(sanitizeOriginalName('re;port$(whoami).pdf')).toBe(
+      're_port__whoami_.pdf',
+    );
+  });
+
+  it('drops embedded null bytes and control characters', () => {
+    expect(sanitizeOriginalName('report\u0000.pdf\u0007')).toBe('report.pdf');
+  });
+
+  it('caps very long names', () => {
+    expect(sanitizeOriginalName('a'.repeat(500)).length).toBe(128);
+  });
+
+  it('falls back to a placeholder for empty or missing names', () => {
+    expect(sanitizeOriginalName(undefined)).toBe('unnamed');
+    expect(sanitizeOriginalName('')).toBe('unnamed');
+    expect(sanitizeOriginalName('...')).toBe('unnamed');
+  });
+});
+
+describe('hasSignature', () => {
+  it('matches a leading prefix', () => {
+    expect(hasSignature(PDF, Buffer.from('%PDF-'))).toBe(true);
+  });
+
+  it('does not match when the prefix appears later', () => {
+    expect(hasSignature(Buffer.from('xx%PDF-'), Buffer.from('%PDF-'))).toBe(
+      false,
+    );
+  });
+
+  it('handles buffers shorter than the signature', () => {
+    expect(hasSignature(Buffer.from('%P'), Buffer.from('%PDF-'))).toBe(false);
+  });
+});
+
+describe('validateUploadedFile', () => {
+  it.each([
+    ['application/pdf', 'doc.pdf', PDF],
+    ['image/png', 'logo.png', PNG],
+    ['image/jpeg', 'photo.jpg', JPEG],
+    ['image/jpeg', 'photo.jpeg', JPEG],
+  ])('accepts a well-formed %s', (mime, name, buffer) => {
+    const result = validateUploadedFile(buffer, mime, name);
+
+    expect(result.valid).toBe(true);
+    expect(result.type?.mimeType).toBe(mime);
+  });
+
+  it('accepts a content type carrying parameters', () => {
+    expect(
+      validateUploadedFile(PDF, 'application/pdf; charset=binary', 'doc.pdf')
+        .valid,
+    ).toBe(true);
+  });
+
+  it('rejects an empty file', () => {
+    const result = validateUploadedFile(
+      Buffer.alloc(0),
+      'application/pdf',
+      'a.pdf',
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/empty/i);
+  });
+
+  it('rejects a content type outside the allow-list', () => {
+    const result = validateUploadedFile(
+      Buffer.from('MZ\x90\x00'),
+      'application/x-msdownload',
+      'setup.exe',
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/Unsupported content type/);
+  });
+
+  it('rejects an extension that disagrees with the content type', () => {
+    const result = validateUploadedFile(PDF, 'application/pdf', 'doc.png');
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/does not match content type/);
+  });
+
+  it('rejects a file with no extension', () => {
+    const result = validateUploadedFile(PDF, 'application/pdf', 'doc');
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/Extension "none"/);
+  });
+
+  // The core content-confusion case: everything the caller controls says PDF,
+  // but the bytes are an executable.
+  it('rejects an executable masquerading as a PDF', () => {
+    const result = validateUploadedFile(
+      Buffer.from('MZ\x90\x00\x03\x00\x00\x00'),
+      'application/pdf',
+      'invoice.pdf',
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/do not match the declared type/);
+  });
+
+  it('rejects a shell script renamed to .png', () => {
+    const result = validateUploadedFile(
+      Buffer.from('#!/bin/sh\nrm -rf /\n'),
+      'image/png',
+      'avatar.png',
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/do not match the declared type/);
+  });
+
+  it('rejects PNG bytes declared as JPEG', () => {
+    const result = validateUploadedFile(PNG, 'image/jpeg', 'photo.jpg');
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/do not match the declared type/);
+  });
+
+  it('rejects a traversal filename whose sanitized extension no longer matches', () => {
+    const result = validateUploadedFile(
+      PDF,
+      'application/pdf',
+      '../../evil.png',
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a missing content type', () => {
+    expect(validateUploadedFile(PDF, undefined, 'doc.pdf').valid).toBe(false);
+  });
+});

--- a/src/worker/file-validation.ts
+++ b/src/worker/file-validation.ts
@@ -1,0 +1,88 @@
+import { extname } from 'node:path';
+import { ALLOWED_FILE_TYPES, AllowedFileType } from './upload.constants';
+
+export interface FileValidationResult {
+  valid: boolean;
+  /** The allow-list entry the file matched, when valid. */
+  type?: AllowedFileType;
+  /** Extension (including the dot) that should be used for storage. */
+  extension?: string;
+  reason?: string;
+}
+
+/**
+ * Strips directory components, control characters and leading dots from a
+ * caller-supplied filename so it can be stored as metadata without being able
+ * to influence any path.
+ *
+ * The sanitized value is *never* used to build a storage path — see
+ * `FileStorageService`, which always generates its own random name.
+ */
+export function sanitizeOriginalName(name: string | undefined): string {
+  if (!name) return 'unnamed';
+
+  // Take the basename under both POSIX and Windows separators.
+  const base = name.split(/[\\/]/).pop() ?? 'unnamed';
+
+  const cleaned = base
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .replace(/^\.+/, '')
+    .slice(0, 128);
+
+  return cleaned.length > 0 ? cleaned : 'unnamed';
+}
+
+/** True when `buffer` starts with `signature`. */
+export function hasSignature(buffer: Buffer, signature: Buffer): boolean {
+  if (buffer.length < signature.length) return false;
+  return buffer.subarray(0, signature.length).equals(signature);
+}
+
+/**
+ * Validates a buffer against the upload allow-list.
+ *
+ * All three of the declared MIME type, the filename extension and the leading
+ * magic bytes must agree; a mismatch between any pair is rejected, since that
+ * is the signature of a content-type confusion attempt.
+ */
+export function validateUploadedFile(
+  buffer: Buffer,
+  declaredMimeType: string | undefined,
+  originalName: string | undefined,
+): FileValidationResult {
+  if (!buffer || buffer.length === 0) {
+    return { valid: false, reason: 'File is empty' };
+  }
+
+  const mimeType = (declaredMimeType ?? '').split(';')[0].trim().toLowerCase();
+  const type = ALLOWED_FILE_TYPES.find((entry) => entry.mimeType === mimeType);
+
+  if (!type) {
+    return {
+      valid: false,
+      reason: `Unsupported content type "${declaredMimeType ?? 'unknown'}"`,
+    };
+  }
+
+  const extension = extname(sanitizeOriginalName(originalName)).toLowerCase();
+  if (!type.extensions.includes(extension)) {
+    return {
+      valid: false,
+      reason: `Extension "${extension || 'none'}" does not match content type "${mimeType}"`,
+    };
+  }
+
+  const signatureMatches = type.signatures.some((signature) =>
+    hasSignature(buffer, signature),
+  );
+  if (!signatureMatches) {
+    return {
+      valid: false,
+      reason: `File contents do not match the declared type "${mimeType}"`,
+    };
+  }
+
+  return { valid: true, type, extension };
+}

--- a/src/worker/malware-scanner.service.spec.ts
+++ b/src/worker/malware-scanner.service.spec.ts
@@ -1,0 +1,133 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import {
+  EICAR_SIGNATURE,
+  MalwareScannerService,
+  ScanVerdict,
+} from './malware-scanner.service';
+
+const config: Record<string, unknown> = {};
+
+describe('MalwareScannerService', () => {
+  let scanner: MalwareScannerService;
+
+  beforeEach(async () => {
+    for (const key of Object.keys(config)) delete config[key];
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MalwareScannerService,
+        {
+          provide: ConfigService,
+          useValue: { get: (key: string) => config[key] },
+        },
+      ],
+    }).compile();
+
+    scanner = module.get(MalwareScannerService);
+  });
+
+  it('defaults to the built-in engine', () => {
+    expect(scanner.engine).toBe('builtin');
+  });
+
+  describe('clean files', () => {
+    it('passes an ordinary PDF', async () => {
+      const result = await scanner.scan(
+        Buffer.from('%PDF-1.7\nJust a normal document.\n'),
+      );
+
+      expect(result.verdict).toBe(ScanVerdict.CLEAN);
+      expect(result.signature).toBeNull();
+    });
+
+    it('passes binary image data', async () => {
+      const result = await scanner.scan(
+        Buffer.concat([
+          Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+          Buffer.alloc(256, 0x42),
+        ]),
+      );
+
+      expect(result.verdict).toBe(ScanVerdict.CLEAN);
+    });
+
+    it('reports the engine, timestamp and duration', async () => {
+      const result = await scanner.scan(Buffer.from('%PDF-1.7\n'));
+
+      expect(result.engine).toBe('builtin');
+      expect(result.scannedAt).toBeInstanceOf(Date);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('detections', () => {
+    it('detects the EICAR test file', async () => {
+      const result = await scanner.scan(Buffer.from(EICAR_SIGNATURE, 'ascii'));
+
+      expect(result.verdict).toBe(ScanVerdict.INFECTED);
+      expect(result.signature).toBe('Eicar-Test-Signature');
+    });
+
+    it('detects EICAR embedded inside a larger file', async () => {
+      const result = await scanner.scan(
+        Buffer.concat([
+          Buffer.from('%PDF-1.7\n'),
+          Buffer.from(EICAR_SIGNATURE, 'ascii'),
+          Buffer.from('\ntrailer\n'),
+        ]),
+      );
+
+      expect(result.verdict).toBe(ScanVerdict.INFECTED);
+    });
+
+    it.each([
+      [
+        'a PDF auto-running JavaScript',
+        '%PDF-1.7\n/OpenAction << /S /JavaScript /JS (app.alert(1)) >>',
+        'Heuristic.PDF.OpenAction.JavaScript',
+      ],
+      [
+        'a PDF launch action',
+        '%PDF-1.7\n<< /Type /Action /Launch /F (cmd.exe) >>',
+        'Heuristic.PDF.Launch',
+      ],
+      [
+        'an embedded HTML script tag',
+        '%PDF-1.7\n<script>fetch("//evil")</script>',
+        'Heuristic.Script.EmbeddedHtml',
+      ],
+      [
+        'an embedded PHP tag',
+        '%PDF-1.7\n<?php system($_GET["c"]); ?>',
+        'Heuristic.Script.PhpTag',
+      ],
+      ['a shell script', '#!/bin/sh\nrm -rf /\n', 'Heuristic.Script.Shebang'],
+    ])('flags %s', async (_label, content, signature) => {
+      const result = await scanner.scan(Buffer.from(content));
+
+      expect(result.verdict).toBe(ScanVerdict.INFECTED);
+      expect(result.signature).toBe(signature);
+    });
+  });
+
+  describe('clamav backend', () => {
+    beforeEach(() => {
+      config['uploads.scanner.provider'] = 'clamav';
+      // Port 1 is reserved and refuses connections immediately.
+      config['uploads.scanner.host'] = '127.0.0.1';
+      config['uploads.scanner.port'] = 1;
+      config['uploads.scanner.timeoutMs'] = 1000;
+    });
+
+    it('reports ERROR rather than CLEAN when the daemon is unreachable', async () => {
+      const result = await scanner.scan(Buffer.from('%PDF-1.7\n'));
+
+      // Fails closed: an unreachable scanner must never look like a pass.
+      expect(result.verdict).toBe(ScanVerdict.ERROR);
+      expect(result.verdict).not.toBe(ScanVerdict.CLEAN);
+      expect(result.engine).toBe('clamav');
+      expect(result.details).toBeTruthy();
+    });
+  });
+});

--- a/src/worker/malware-scanner.service.ts
+++ b/src/worker/malware-scanner.service.ts
@@ -1,0 +1,195 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as net from 'node:net';
+
+export enum ScanVerdict {
+  CLEAN = 'clean',
+  INFECTED = 'infected',
+  /** The scanner could not reach a verdict (timeout, transport failure). */
+  ERROR = 'error',
+}
+
+export interface ScanResult {
+  verdict: ScanVerdict;
+  /** Scanner-reported signature name, when infected. */
+  signature: string | null;
+  /** Which backend produced the verdict. */
+  engine: string;
+  scannedAt: Date;
+  durationMs: number;
+  details?: string;
+}
+
+/**
+ * The EICAR anti-malware test string. Every real scanner flags it, and the
+ * built-in scanner does too, so the quarantine path can be exercised end to end
+ * without handling an actual sample.
+ */
+export const EICAR_SIGNATURE =
+  'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
+
+/**
+ * Heuristics applied by the built-in scanner. These are deliberately
+ * conservative: they catch active content smuggled into documents and images,
+ * which is the realistic risk for a PDF/PNG/JPEG allow-list. They are a
+ * defence-in-depth layer, not a replacement for ClamAV in production.
+ */
+const HEURISTIC_PATTERNS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
+  {
+    name: 'Heuristic.PDF.OpenAction.JavaScript',
+    pattern: /\/OpenAction[\s\S]{0,200}\/JavaScript/i,
+  },
+  { name: 'Heuristic.PDF.EmbeddedJavaScript', pattern: /\/JS\s*\(/i },
+  { name: 'Heuristic.PDF.Launch', pattern: /\/Launch\s*(<<|\/)/i },
+  { name: 'Heuristic.Script.EmbeddedHtml', pattern: /<script[\s>]/i },
+  { name: 'Heuristic.Script.PhpTag', pattern: /<\?php/i },
+  { name: 'Heuristic.Script.Shebang', pattern: /^#!\s*\/(bin|usr)\//ims },
+];
+
+/**
+ * Scans upload payloads for malware.
+ *
+ * Two backends are available, selected by `MALWARE_SCAN_PROVIDER`:
+ *  - `builtin` (default): EICAR detection plus the heuristics above. No
+ *    external dependency, so it works in CI and local development.
+ *  - `clamav`: streams the buffer to a clamd daemon over TCP (INSTREAM).
+ *
+ * A backend that fails or times out returns {@link ScanVerdict.ERROR}, which the
+ * caller treats as "not releasable" — the scanner fails closed.
+ */
+@Injectable()
+export class MalwareScannerService {
+  private readonly logger = new Logger(MalwareScannerService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  get engine(): string {
+    return (
+      this.configService.get<string>('uploads.scanner.provider') ?? 'builtin'
+    );
+  }
+
+  async scan(buffer: Buffer, label = 'upload'): Promise<ScanResult> {
+    const startedAt = Date.now();
+    const engine = this.engine;
+
+    try {
+      const result =
+        engine === 'clamav'
+          ? await this.scanWithClamAv(buffer)
+          : this.scanWithBuiltin(buffer);
+
+      return {
+        ...result,
+        engine,
+        scannedAt: new Date(),
+        durationMs: Date.now() - startedAt,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Malware scan failed for ${label}: ${message}`);
+      return {
+        verdict: ScanVerdict.ERROR,
+        signature: null,
+        engine,
+        scannedAt: new Date(),
+        durationMs: Date.now() - startedAt,
+        details: message,
+      };
+    }
+  }
+
+  /** Dependency-free scanner used by default and in tests. */
+  private scanWithBuiltin(
+    buffer: Buffer,
+  ): Pick<ScanResult, 'verdict' | 'signature' | 'details'> {
+    const text = buffer.toString('latin1');
+
+    if (text.includes(EICAR_SIGNATURE)) {
+      return {
+        verdict: ScanVerdict.INFECTED,
+        signature: 'Eicar-Test-Signature',
+      };
+    }
+
+    for (const { name, pattern } of HEURISTIC_PATTERNS) {
+      if (pattern.test(text)) {
+        return { verdict: ScanVerdict.INFECTED, signature: name };
+      }
+    }
+
+    return { verdict: ScanVerdict.CLEAN, signature: null };
+  }
+
+  /**
+   * clamd INSTREAM protocol: `zINSTREAM\0`, then length-prefixed chunks, then a
+   * zero-length chunk. clamd replies `stream: OK` or `stream: <sig> FOUND`.
+   */
+  private scanWithClamAv(
+    buffer: Buffer,
+  ): Promise<Pick<ScanResult, 'verdict' | 'signature' | 'details'>> {
+    const host =
+      this.configService.get<string>('uploads.scanner.host') ?? '127.0.0.1';
+    const port = this.configService.get<number>('uploads.scanner.port') ?? 3310;
+    const timeoutMs =
+      this.configService.get<number>('uploads.scanner.timeoutMs') ?? 30_000;
+    const chunkSize = 64 * 1024;
+
+    return new Promise((resolve, reject) => {
+      const socket = net.createConnection({ host, port });
+      const chunks: Buffer[] = [];
+      let settled = false;
+
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        socket.destroy();
+        fn();
+      };
+
+      socket.setTimeout(timeoutMs, () =>
+        finish(() =>
+          reject(new Error(`clamd did not respond within ${timeoutMs}ms`)),
+        ),
+      );
+
+      socket.on('error', (err) => finish(() => reject(err)));
+      socket.on('data', (chunk) => chunks.push(chunk));
+
+      socket.on('connect', () => {
+        socket.write('zINSTREAM\0');
+        for (let offset = 0; offset < buffer.length; offset += chunkSize) {
+          const slice = buffer.subarray(offset, offset + chunkSize);
+          const header = Buffer.alloc(4);
+          header.writeUInt32BE(slice.length, 0);
+          socket.write(header);
+          socket.write(slice);
+        }
+        // Zero-length chunk terminates the stream.
+        socket.write(Buffer.from([0, 0, 0, 0]));
+      });
+
+      socket.on('end', () =>
+        finish(() => {
+          const reply = Buffer.concat(chunks).toString('utf8').trim();
+
+          if (/\bOK$/.test(reply)) {
+            resolve({ verdict: ScanVerdict.CLEAN, signature: null });
+            return;
+          }
+
+          const found = /^stream:\s*(.+?)\s+FOUND$/m.exec(reply);
+          if (found) {
+            resolve({
+              verdict: ScanVerdict.INFECTED,
+              signature: found[1],
+            });
+            return;
+          }
+
+          reject(new Error(`Unexpected clamd response: ${reply || '<empty>'}`));
+        }),
+      );
+    });
+  }
+}

--- a/src/worker/schemas/worker-upload.schema.ts
+++ b/src/worker/schemas/worker-upload.schema.ts
@@ -1,0 +1,83 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
+import { UploadStatus } from '../upload.constants';
+import { StorageArea } from '../file-storage.service';
+
+export type WorkerUploadDocument = HydratedDocument<WorkerUpload>;
+
+export class UploadScanRecord {
+  verdict: string;
+  signature: string | null;
+  engine: string;
+  scannedAt: Date;
+  durationMs: number;
+  details?: string;
+}
+
+@Schema({ collection: 'worker_uploads', timestamps: true })
+export class WorkerUpload {
+  /** Authenticated uploader; quotas and reads are scoped to this. */
+  @Prop({ required: true, index: true })
+  ownerId: string;
+
+  /** Generated storage name — never caller-supplied. */
+  @Prop({ required: true, unique: true })
+  storageKey: string;
+
+  /** Which storage area currently holds the bytes. */
+  @Prop({
+    type: String,
+    required: true,
+    enum: Object.values(StorageArea),
+    default: StorageArea.QUARANTINE,
+  })
+  storageArea: StorageArea;
+
+  /** Sanitized original filename, kept for display only. */
+  @Prop({ required: true })
+  originalName: string;
+
+  @Prop({ required: true })
+  mimeType: string;
+
+  @Prop({ required: true })
+  size: number;
+
+  @Prop({ required: true })
+  sha256: string;
+
+  @Prop({
+    type: String,
+    required: true,
+    enum: Object.values(UploadStatus),
+    default: UploadStatus.PENDING,
+    index: true,
+  })
+  status: UploadStatus;
+
+  @Prop({ type: MongooseSchema.Types.Mixed, default: null })
+  scan: UploadScanRecord | null;
+
+  @Prop({ type: String, default: null })
+  title: string | null;
+
+  @Prop({ type: String, default: null })
+  description: string | null;
+
+  @Prop({ type: [String], default: [] })
+  tags: string[];
+
+  @Prop({ type: Date, default: null })
+  releasedAt: Date | null;
+
+  @Prop({ type: Date, default: null })
+  quarantinedAt: Date | null;
+
+  readonly createdAt?: Date;
+  readonly updatedAt?: Date;
+}
+
+export const WorkerUploadSchema = SchemaFactory.createForClass(WorkerUpload);
+
+// Quota lookups: bytes and file counts per owner within a rolling window.
+WorkerUploadSchema.index({ ownerId: 1, createdAt: -1 });

--- a/src/worker/upload.constants.ts
+++ b/src/worker/upload.constants.ts
@@ -1,0 +1,57 @@
+/**
+ * Upload lifecycle states.
+ *
+ * A file is only ever readable in the `CLEAN` state. Everything else keeps the
+ * bytes inside the quarantine tree (or removes them entirely).
+ */
+export enum UploadStatus {
+  /** Accepted, written to quarantine, not yet scanned. */
+  PENDING = 'pending',
+  /** A scan is in flight. */
+  SCANNING = 'scanning',
+  /** Scanned and released to the clean store. */
+  CLEAN = 'clean',
+  /** Scanner reported a detection; bytes quarantined or deleted. */
+  INFECTED = 'infected',
+  /** Scanner could not produce a verdict; treated as unavailable. */
+  ERROR = 'error',
+}
+
+/** Statuses whose bytes may be served to a caller. */
+export const SERVABLE_STATUSES: readonly UploadStatus[] = [UploadStatus.CLEAN];
+
+/**
+ * Allow-list of accepted upload types.
+ *
+ * Each entry pins the MIME type to its permitted extensions *and* to the magic
+ * byte prefix that must appear at the start of the file, so a caller cannot
+ * pass a script through by lying about `Content-Type` or the filename.
+ */
+export interface AllowedFileType {
+  mimeType: string;
+  extensions: readonly string[];
+  /** Byte prefixes, any of which is a valid signature for this type. */
+  signatures: readonly Buffer[];
+}
+
+export const ALLOWED_FILE_TYPES: readonly AllowedFileType[] = [
+  {
+    mimeType: 'application/pdf',
+    extensions: ['.pdf'],
+    signatures: [Buffer.from('%PDF-', 'ascii')],
+  },
+  {
+    mimeType: 'image/png',
+    extensions: ['.png'],
+    signatures: [Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
+  },
+  {
+    mimeType: 'image/jpeg',
+    extensions: ['.jpg', '.jpeg'],
+    signatures: [Buffer.from([0xff, 0xd8, 0xff])],
+  },
+];
+
+export const ALLOWED_MIME_TYPES: readonly string[] = ALLOWED_FILE_TYPES.map(
+  (type) => type.mimeType,
+);

--- a/src/worker/worker.controller.ts
+++ b/src/worker/worker.controller.ts
@@ -1,61 +1,156 @@
-import { BadRequestException, Body, Controller, ParseFilePipeBuilder, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Res,
+  StreamableFile,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { diskStorage } from 'multer';
-import { extname } from 'node:path';
-import { mkdirSync } from 'node:fs';
+import { memoryStorage } from 'multer';
+import type { Response } from 'express';
+import {
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { WorkerService } from './worker.service';
+import type { UploadedFileBuffer } from './worker.service';
 import { UploadWorkerFileDto } from './dto/upload-worker-file.dto';
-import { Public } from '../common/decorators/public.decorator';
+import { ALLOWED_MIME_TYPES } from './upload.constants';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '../common/enums/role.enum';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ParseObjectIdPipe } from '../common/pipes/parse-object-id.pipe';
+import { AuditActor } from '../common/audit/audit-context';
+import type { AuditContext } from '../common/audit/audit-context';
 
-interface MulterFile {
-  originalname: string;
-  filename: string;
-  mimetype: string;
-  size: number;
-}
+/**
+ * Hard ceiling enforced by multer before the body is buffered. The
+ * configurable, per-request limit is re-checked in the service; this only stops
+ * an unbounded stream from being read into memory in the first place.
+ */
+const MULTER_MAX_BYTES = 10 * 1024 * 1024;
 
-const uploadDirectory = 'uploads/worker';
-
-@Public()
+@ApiBearerAuth('access-token')
+@ApiTags('Worker Uploads')
 @Controller('worker')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN, Role.MODERATOR, Role.TUTOR)
 export class WorkerController {
   constructor(private readonly workerService: WorkerService) {}
 
+  /**
+   * Uploads are buffered in memory rather than written straight to disk, so
+   * nothing untrusted touches the filesystem until it has passed MIME, magic
+   * byte and quota checks. The service then writes it to quarantine and scans
+   * it; the response reports the resulting status.
+   */
   @Post('upload')
+  @ApiOperation({
+    summary:
+      'Upload a file (quarantined and scanned before it becomes available)',
+  })
+  @ApiConsumes('multipart/form-data')
   @UseInterceptors(
     FileInterceptor('file', {
-      storage: diskStorage({
-        destination: (_req: any, _file: any, callback: any) => {
-          mkdirSync(uploadDirectory, { recursive: true });
-          callback(null, uploadDirectory);
-        },
-        filename: (_req: any, file: any, callback: any) => {
-          const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-          const extension = extname(file.originalname) || '';
-          callback(null, `${uniqueSuffix}${extension.toLowerCase()}`);
-        },
-      }),
+      storage: memoryStorage(),
+      limits: { fileSize: MULTER_MAX_BYTES, files: 1, fields: 10 },
+      fileFilter: (_req, file, callback) => {
+        // Cheap pre-filter; the authoritative check is magic byte validation.
+        if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+          callback(
+            new BadRequestException(
+              `Unsupported content type "${file.mimetype}"`,
+            ),
+            false,
+          );
+          return;
+        }
+        callback(null, true);
+      },
     }),
   )
   upload(
-    @UploadedFile(
-      new ParseFilePipeBuilder()
-        .addFileTypeValidator({
-          fileType: /^(application\/pdf|image\/png|image\/jpeg)$/,
-        })
-        .addMaxSizeValidator({ maxSize: 5 * 1024 * 1024 })
-        .build({
-          fileIsRequired: true,
-          errorHttpStatusCode: 400,
-        }),
-    )
-    file: MulterFile,
+    @UploadedFile() file: UploadedFileBuffer,
     @Body() payload: UploadWorkerFileDto,
+    @CurrentUser('sub') ownerId: string,
+    @AuditActor() audit: AuditContext,
   ) {
     if (!file) {
       throw new BadRequestException('File is required');
     }
+    return this.workerService.processUpload(file, payload, ownerId, audit);
+  }
 
-    return this.workerService.processUpload(file, payload);
+  @Get('files')
+  @ApiOperation({ summary: 'List your uploads and their scan status' })
+  list(@CurrentUser('sub') ownerId: string) {
+    return this.workerService.listUploads(ownerId);
+  }
+
+  @Get('files/:id')
+  @ApiOperation({ summary: 'Get upload metadata and scan status' })
+  getOne(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @CurrentUser('sub') requesterId: string,
+    @CurrentUser('role') requesterRole: string,
+  ) {
+    return this.workerService.getUpload(id, requesterId, requesterRole);
+  }
+
+  /**
+   * Serves the bytes. Returns 409 while the file is pending, scanning,
+   * quarantined or unscannable — only a released file is readable.
+   */
+  @Get('files/:id/content')
+  @ApiOperation({ summary: 'Download a released (scanned clean) file' })
+  async download(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @CurrentUser('sub') requesterId: string,
+    @CurrentUser('role') requesterRole: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<StreamableFile> {
+    const { stream, upload } = await this.workerService.openDownload(
+      id,
+      requesterId,
+      requesterRole,
+    );
+
+    res.setHeader('Content-Type', upload.mimeType);
+    // Always an attachment: never let the browser render uploaded content
+    // inline on the API origin.
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${upload.originalName}"`,
+    );
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+
+    return new StreamableFile(stream);
+  }
+
+  @Delete('files/:id')
+  @ApiOperation({ summary: 'Delete an upload and its stored bytes' })
+  remove(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @CurrentUser('sub') requesterId: string,
+    @CurrentUser('role') requesterRole: string,
+    @AuditActor() audit: AuditContext,
+  ) {
+    return this.workerService.deleteUpload(
+      id,
+      requesterId,
+      requesterRole,
+      audit,
+    );
   }
 }

--- a/src/worker/worker.module.ts
+++ b/src/worker/worker.module.ts
@@ -1,9 +1,22 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
 import { WorkerController } from './worker.controller';
 import { WorkerService } from './worker.service';
+import { FileStorageService } from './file-storage.service';
+import { MalwareScannerService } from './malware-scanner.service';
+import {
+  WorkerUpload,
+  WorkerUploadSchema,
+} from './schemas/worker-upload.schema';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: WorkerUpload.name, schema: WorkerUploadSchema },
+    ]),
+  ],
   controllers: [WorkerController],
-  providers: [WorkerService],
+  providers: [WorkerService, FileStorageService, MalwareScannerService],
+  exports: [WorkerService],
 })
 export class WorkerModule {}

--- a/src/worker/worker.service.spec.ts
+++ b/src/worker/worker.service.spec.ts
@@ -1,0 +1,462 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+  PayloadTooLargeException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getModelToken } from '@nestjs/mongoose';
+import { WorkerService, parseTags } from './worker.service';
+import { WorkerUpload } from './schemas/worker-upload.schema';
+import { UploadStatus } from './upload.constants';
+import { FileStorageService, StorageArea } from './file-storage.service';
+import {
+  EICAR_SIGNATURE,
+  MalwareScannerService,
+  ScanVerdict,
+} from './malware-scanner.service';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction, AuditOutcome } from '../common/audit/audit-action.enum';
+import { AuditContext } from '../common/audit/audit-context';
+
+const PDF = Buffer.from('%PDF-1.7\nhello\n');
+const EICAR_PDF = Buffer.concat([
+  Buffer.from('%PDF-1.7\n'),
+  Buffer.from(EICAR_SIGNATURE, 'ascii'),
+]);
+
+const audit: AuditContext = {
+  actorId: 'tutor-1',
+  actorEmail: 'tutor@chainverse.io',
+  actorRole: 'tutor',
+  requestId: 'req-upload-1',
+  ip: '10.1.1.1',
+  userAgent: 'jest',
+};
+
+const config: Record<string, unknown> = {};
+
+/** Simulated document store — captures the saved state of each upload. */
+class FakeUploadDoc {
+  id = `upload-${Math.random().toString(16).slice(2, 8)}`;
+  saveCount = 0;
+  createdAt = new Date('2026-07-01T00:00:00.000Z');
+  [key: string]: any;
+
+  constructor(payload: Record<string, unknown>) {
+    Object.assign(this, payload);
+  }
+
+  save() {
+    this.saveCount += 1;
+    return Promise.resolve(this);
+  }
+}
+
+let created: FakeUploadDoc[] = [];
+const mockUploadModel: any = jest
+  .fn()
+  .mockImplementation((payload: Record<string, unknown>) => {
+    const doc = new FakeUploadDoc(payload);
+    created.push(doc);
+    return doc;
+  });
+
+const exec = <T>(value: T) => ({ exec: jest.fn().mockResolvedValue(value) });
+
+const storage = {
+  storeInQuarantine: jest.fn(),
+  move: jest.fn().mockResolvedValue('/var/uploads/clean/x'),
+  remove: jest.fn().mockResolvedValue(undefined),
+  exists: jest.fn().mockResolvedValue(true),
+  createReadStream: jest.fn().mockReturnValue({ pipe: jest.fn() }),
+};
+
+const scanner = { scan: jest.fn() };
+const auditService = { record: jest.fn().mockResolvedValue(null) };
+
+const cleanScan = {
+  verdict: ScanVerdict.CLEAN,
+  signature: null,
+  engine: 'builtin',
+  scannedAt: new Date(),
+  durationMs: 3,
+};
+const infectedScan = {
+  verdict: ScanVerdict.INFECTED,
+  signature: 'Eicar-Test-Signature',
+  engine: 'builtin',
+  scannedAt: new Date(),
+  durationMs: 4,
+};
+const erroredScan = {
+  verdict: ScanVerdict.ERROR,
+  signature: null,
+  engine: 'clamav',
+  scannedAt: new Date(),
+  durationMs: 5,
+  details: 'connection refused',
+};
+
+/** Audit entries recorded for a given action. */
+const auditEntriesFor = (action: AuditAction) =>
+  auditService.record.mock.calls
+    .map(([entry]) => entry)
+    .filter((entry) => entry.action === action);
+
+describe('WorkerService', () => {
+  let service: WorkerService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    created = [];
+    for (const key of Object.keys(config)) delete config[key];
+
+    storage.storeInQuarantine.mockResolvedValue({
+      storageKey: 'generated-key.pdf',
+      area: StorageArea.QUARANTINE,
+      absolutePath: '/var/uploads/quarantine/generated-key.pdf',
+      size: PDF.length,
+      sha256: 'abc123',
+    });
+    storage.move.mockResolvedValue('/var/uploads/clean/generated-key.pdf');
+    storage.exists.mockResolvedValue(true);
+    scanner.scan.mockResolvedValue(cleanScan);
+    auditService.record.mockResolvedValue(null);
+
+    // No prior uploads: quota checks pass by default.
+    mockUploadModel.countDocuments = jest.fn().mockReturnValue(exec(0));
+    mockUploadModel.aggregate = jest.fn().mockReturnValue(exec([]));
+    mockUploadModel.findById = jest.fn().mockReturnValue(exec(null));
+    mockUploadModel.findByIdAndDelete = jest.fn().mockReturnValue(exec(null));
+    mockUploadModel.find = jest.fn().mockReturnValue({
+      sort: () => ({ limit: () => exec([]) }),
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WorkerService,
+        {
+          provide: getModelToken(WorkerUpload.name),
+          useValue: mockUploadModel,
+        },
+        { provide: FileStorageService, useValue: storage },
+        { provide: MalwareScannerService, useValue: scanner },
+        { provide: AuditService, useValue: auditService },
+        {
+          provide: ConfigService,
+          useValue: { get: (key: string) => config[key] },
+        },
+      ],
+    }).compile();
+
+    service = module.get(WorkerService);
+  });
+
+  const upload = (buffer = PDF, over: Record<string, unknown> = {}) =>
+    service.processUpload(
+      {
+        originalname: 'doc.pdf',
+        mimetype: 'application/pdf',
+        size: buffer.length,
+        buffer,
+        ...over,
+      },
+      {},
+      'tutor-1',
+      audit,
+    );
+
+  describe('validation before anything touches disk', () => {
+    it('rejects an empty upload', async () => {
+      await expect(upload(Buffer.alloc(0))).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(storage.storeInQuarantine).not.toHaveBeenCalled();
+    });
+
+    it('rejects a file over the size limit without storing it', async () => {
+      config['uploads.maxFileBytes'] = 8;
+
+      await expect(upload()).rejects.toThrow(PayloadTooLargeException);
+      expect(storage.storeInQuarantine).not.toHaveBeenCalled();
+    });
+
+    it('rejects an executable disguised as a PDF without storing it', async () => {
+      await expect(upload(Buffer.from('MZ\x90\x00'))).rejects.toThrow(
+        /do not match the declared type/,
+      );
+      expect(storage.storeInQuarantine).not.toHaveBeenCalled();
+      expect(scanner.scan).not.toHaveBeenCalled();
+    });
+
+    it('audits a rejected upload as a denial', async () => {
+      await expect(upload(Buffer.from('MZ\x90\x00'))).rejects.toThrow();
+
+      const [entry] = auditEntriesFor(AuditAction.FILE_UPLOAD_REJECTED);
+      expect(entry.outcome).toBe(AuditOutcome.DENIED);
+      expect(entry.context).toBe(audit);
+      expect(entry.reason).toMatch(/do not match the declared type/);
+    });
+  });
+
+  describe('quotas', () => {
+    it('rejects once the per-window file count is reached', async () => {
+      config['uploads.quota.maxFiles'] = 2;
+      mockUploadModel.countDocuments.mockReturnValue(exec(2));
+
+      await expect(upload()).rejects.toThrow(ForbiddenException);
+      expect(storage.storeInQuarantine).not.toHaveBeenCalled();
+    });
+
+    it('rejects once the stored byte quota would be exceeded', async () => {
+      config['uploads.quota.maxBytes'] = 20;
+      mockUploadModel.aggregate.mockReturnValue(exec([{ total: 18 }]));
+
+      await expect(upload()).rejects.toThrow(/Storage quota exceeded/);
+    });
+
+    it('scopes the quota query to the uploading user', async () => {
+      await upload();
+
+      expect(mockUploadModel.countDocuments).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerId: 'tutor-1' }),
+      );
+    });
+  });
+
+  describe('quarantine and release lifecycle', () => {
+    it('writes to quarantine and records the upload as pending first', async () => {
+      await upload();
+
+      expect(storage.storeInQuarantine).toHaveBeenCalledWith(PDF, '.pdf');
+      const [doc] = created;
+      expect(doc.storageKey).toBe('generated-key.pdf');
+      expect(doc.ownerId).toBe('tutor-1');
+    });
+
+    it('never stores the caller-supplied filename as the storage key', async () => {
+      await upload(PDF, { originalname: '../../etc/cron.d/evil.pdf' });
+
+      const [doc] = created;
+      expect(doc.storageKey).toBe('generated-key.pdf');
+      expect(doc.originalName).toBe('evil.pdf');
+      expect(doc.originalName).not.toContain('..');
+    });
+
+    it('releases a clean file to the clean area', async () => {
+      const view = await upload();
+
+      expect(storage.move).toHaveBeenCalledWith(
+        'generated-key.pdf',
+        StorageArea.QUARANTINE,
+        StorageArea.CLEAN,
+      );
+      expect(view.status).toBe(UploadStatus.CLEAN);
+      expect(view.downloadUrl).toContain('/content');
+    });
+
+    it('deletes an infected file and never exposes a download URL', async () => {
+      scanner.scan.mockResolvedValue(infectedScan);
+
+      const view = await upload(EICAR_PDF);
+
+      expect(view.status).toBe(UploadStatus.INFECTED);
+      expect(view.downloadUrl).toBeNull();
+      expect(storage.remove).toHaveBeenCalledWith(
+        'generated-key.pdf',
+        StorageArea.QUARANTINE,
+      );
+      expect(storage.move).not.toHaveBeenCalled();
+    });
+
+    it('retains an infected sample when configured to', async () => {
+      config['uploads.retainInfected'] = true;
+      scanner.scan.mockResolvedValue(infectedScan);
+
+      const view = await upload(EICAR_PDF);
+
+      expect(storage.move).toHaveBeenCalledWith(
+        'generated-key.pdf',
+        StorageArea.QUARANTINE,
+        StorageArea.INFECTED,
+      );
+      expect(view.status).toBe(UploadStatus.INFECTED);
+      expect(view.downloadUrl).toBeNull();
+    });
+
+    it('leaves an unscannable file quarantined rather than releasing it', async () => {
+      scanner.scan.mockResolvedValue(erroredScan);
+
+      const view = await upload();
+
+      expect(view.status).toBe(UploadStatus.ERROR);
+      expect(view.downloadUrl).toBeNull();
+      expect(storage.move).not.toHaveBeenCalled();
+      expect(storage.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scan auditing', () => {
+    it('audits quarantine, scan and release for a clean file', async () => {
+      await upload();
+
+      expect(auditEntriesFor(AuditAction.FILE_UPLOAD_QUARANTINED)).toHaveLength(
+        1,
+      );
+      expect(auditEntriesFor(AuditAction.FILE_UPLOAD_SCANNED)).toHaveLength(1);
+      expect(auditEntriesFor(AuditAction.FILE_UPLOAD_RELEASED)).toHaveLength(1);
+    });
+
+    it('records the verdict, signature and engine on the scan entry', async () => {
+      scanner.scan.mockResolvedValue(infectedScan);
+
+      await upload(EICAR_PDF);
+
+      const [entry] = auditEntriesFor(AuditAction.FILE_UPLOAD_SCANNED);
+      expect(entry.outcome).toBe(AuditOutcome.FAILURE);
+      expect(entry.after).toEqual(
+        expect.objectContaining({
+          verdict: ScanVerdict.INFECTED,
+          signature: 'Eicar-Test-Signature',
+          engine: 'builtin',
+          status: UploadStatus.INFECTED,
+        }),
+      );
+      expect(entry.reason).toBe('Eicar-Test-Signature');
+    });
+
+    it('does not record a release entry for an infected file', async () => {
+      scanner.scan.mockResolvedValue(infectedScan);
+
+      await upload(EICAR_PDF);
+
+      expect(auditEntriesFor(AuditAction.FILE_UPLOAD_RELEASED)).toHaveLength(0);
+    });
+
+    it('records the scanner failure reason on an errored scan', async () => {
+      scanner.scan.mockResolvedValue(erroredScan);
+
+      await upload();
+
+      const [entry] = auditEntriesFor(AuditAction.FILE_UPLOAD_SCANNED);
+      expect(entry.reason).toBe('connection refused');
+    });
+  });
+
+  describe('openDownload', () => {
+    const storedUpload = (over: Record<string, unknown> = {}) => ({
+      id: 'up-1',
+      ownerId: 'tutor-1',
+      storageKey: 'generated-key.pdf',
+      storageArea: StorageArea.CLEAN,
+      status: UploadStatus.CLEAN,
+      mimeType: 'application/pdf',
+      originalName: 'doc.pdf',
+      ...over,
+    });
+
+    it('serves a released file', async () => {
+      mockUploadModel.findById.mockReturnValue(exec(storedUpload()));
+
+      const { upload: doc } = await service.openDownload('up-1', 'tutor-1');
+
+      expect(doc.status).toBe(UploadStatus.CLEAN);
+      expect(storage.createReadStream).toHaveBeenCalledWith(
+        'generated-key.pdf',
+        StorageArea.CLEAN,
+      );
+    });
+
+    it.each([
+      UploadStatus.PENDING,
+      UploadStatus.SCANNING,
+      UploadStatus.INFECTED,
+      UploadStatus.ERROR,
+    ])('refuses to serve a file in status %s', async (status) => {
+      mockUploadModel.findById.mockReturnValue(exec(storedUpload({ status })));
+
+      await expect(service.openDownload('up-1', 'tutor-1')).rejects.toThrow(
+        ConflictException,
+      );
+      expect(storage.createReadStream).not.toHaveBeenCalled();
+    });
+
+    it("hides another user's upload behind a 404", async () => {
+      mockUploadModel.findById.mockReturnValue(exec(storedUpload()));
+
+      await expect(
+        service.openDownload('up-1', 'someone-else', 'tutor'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('lets a platform admin read any upload', async () => {
+      mockUploadModel.findById.mockReturnValue(exec(storedUpload()));
+
+      await expect(
+        service.openDownload('up-1', 'platform-admin', 'admin'),
+      ).resolves.toBeDefined();
+    });
+
+    it('404s when the metadata survives but the bytes do not', async () => {
+      mockUploadModel.findById.mockReturnValue(exec(storedUpload()));
+      storage.exists.mockResolvedValue(false);
+
+      await expect(service.openDownload('up-1', 'tutor-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('deleteUpload', () => {
+    it('removes the bytes and audits the deletion', async () => {
+      const doc = {
+        id: 'up-1',
+        ownerId: 'tutor-1',
+        storageKey: 'generated-key.pdf',
+        storageArea: StorageArea.CLEAN,
+        status: UploadStatus.CLEAN,
+        sha256: 'abc123',
+      };
+      mockUploadModel.findById.mockReturnValue(exec(doc));
+      mockUploadModel.findByIdAndDelete.mockReturnValue(exec(doc));
+
+      await service.deleteUpload('up-1', 'tutor-1', 'tutor', audit);
+
+      expect(storage.remove).toHaveBeenCalledWith(
+        'generated-key.pdf',
+        StorageArea.CLEAN,
+      );
+      expect(auditEntriesFor(AuditAction.FILE_UPLOAD_DELETED)).toHaveLength(1);
+    });
+
+    it("refuses to delete another user's upload", async () => {
+      mockUploadModel.findById.mockReturnValue(
+        exec({ id: 'up-1', ownerId: 'someone-else' }),
+      );
+
+      await expect(
+        service.deleteUpload('up-1', 'tutor-1', 'tutor', audit),
+      ).rejects.toThrow(NotFoundException);
+      expect(storage.remove).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('parseTags', () => {
+  it('splits, trims and drops blanks', () => {
+    expect(parseTags(' a , b ,, c ')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty list for missing input', () => {
+    expect(parseTags(undefined)).toEqual([]);
+  });
+
+  it('caps the number of tags', () => {
+    const many = Array.from({ length: 50 }, (_, i) => `t${i}`).join(',');
+
+    expect(parseTags(many)).toHaveLength(20);
+  });
+});

--- a/src/worker/worker.service.ts
+++ b/src/worker/worker.service.ts
@@ -1,45 +1,453 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  PayloadTooLargeException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ReadStream } from 'node:fs';
 import { UploadWorkerFileDto } from './dto/upload-worker-file.dto';
+import { SERVABLE_STATUSES, UploadStatus } from './upload.constants';
+import { sanitizeOriginalName, validateUploadedFile } from './file-validation';
+import { FileStorageService, StorageArea } from './file-storage.service';
+import {
+  MalwareScannerService,
+  ScanResult,
+  ScanVerdict,
+} from './malware-scanner.service';
+import {
+  WorkerUpload,
+  WorkerUploadDocument,
+} from './schemas/worker-upload.schema';
+import { AuditService } from '../common/audit/audit.service';
+import { AuditAction, AuditOutcome } from '../common/audit/audit-action.enum';
+import {
+  AuditContext,
+  systemAuditContext,
+} from '../common/audit/audit-context';
+import { Role } from '../common/enums/role.enum';
 
-export interface ProcessedFile {
+/** In-memory multer file handed over by the controller. */
+export interface UploadedFileBuffer {
+  originalname?: string;
+  mimetype?: string;
+  size?: number;
+  buffer: Buffer;
+}
+
+/** Public view of an upload — never exposes the storage path. */
+export interface UploadView {
   id: string;
+  status: string;
   originalName: string;
-  filename: string;
   mimeType: string;
   size: number;
+  sha256: string;
   title: string | null;
   description: string | null;
   tags: string[];
+  scan: {
+    verdict: string;
+    signature: string | null;
+    engine: string;
+    scannedAt: Date;
+  } | null;
+  /** Present only once the file has been released. */
+  downloadUrl: string | null;
   uploadedAt: string;
 }
 
-interface MulterFile {
-  originalname: string;
-  filename: string;
-  mimetype: string;
-  size: number;
-}
+const TARGET_TYPE = 'worker_upload';
 
 @Injectable()
 export class WorkerService {
-  processUpload(file: MulterFile, payload: UploadWorkerFileDto): ProcessedFile {
-    const tags = payload.tags
-      ? payload.tags
-          .split(',')
-          .map((tag: string) => tag.trim())
-          .filter(Boolean)
-      : [];
+  private readonly logger = new Logger(WorkerService.name);
+
+  constructor(
+    @InjectModel(WorkerUpload.name)
+    private readonly uploadModel: Model<WorkerUploadDocument>,
+    private readonly storage: FileStorageService,
+    private readonly scanner: MalwareScannerService,
+    private readonly auditService: AuditService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Full upload lifecycle: validate → quarantine → scan → release or reject.
+   *
+   * The response never carries a download URL for a file that has not passed a
+   * scan, and the bytes stay in the quarantine tree until they do.
+   */
+  async processUpload(
+    file: UploadedFileBuffer,
+    payload: UploadWorkerFileDto,
+    ownerId: string,
+    audit?: AuditContext,
+  ): Promise<UploadView> {
+    const context = audit ?? systemAuditContext();
+
+    if (!file?.buffer || file.buffer.length === 0) {
+      throw new BadRequestException('File is required');
+    }
+
+    const maxBytes = this.maxFileBytes;
+    if (file.buffer.length > maxBytes) {
+      throw new PayloadTooLargeException(
+        `File exceeds the ${maxBytes} byte upload limit`,
+      );
+    }
+
+    // Declared content type, filename extension and magic bytes must agree.
+    const validation = validateUploadedFile(
+      file.buffer,
+      file.mimetype,
+      file.originalname,
+    );
+    if (!validation.valid || !validation.type || !validation.extension) {
+      await this.auditService.record({
+        action: AuditAction.FILE_UPLOAD_REJECTED,
+        context,
+        target: { type: TARGET_TYPE, id: null },
+        outcome: AuditOutcome.DENIED,
+        after: {
+          originalName: sanitizeOriginalName(file.originalname),
+          declaredMimeType: file.mimetype ?? null,
+          size: file.buffer.length,
+        },
+        reason: validation.reason ?? 'Failed upload validation',
+      });
+      throw new BadRequestException(
+        validation.reason ?? 'File failed validation',
+      );
+    }
+
+    await this.assertWithinQuota(ownerId, file.buffer.length);
+
+    const stored = await this.storage.storeInQuarantine(
+      file.buffer,
+      validation.extension,
+    );
+
+    const upload = await new this.uploadModel({
+      ownerId,
+      storageKey: stored.storageKey,
+      storageArea: StorageArea.QUARANTINE,
+      originalName: sanitizeOriginalName(file.originalname),
+      mimeType: validation.type.mimeType,
+      size: stored.size,
+      sha256: stored.sha256,
+      status: UploadStatus.PENDING,
+      title: payload?.title ?? null,
+      description: payload?.description ?? null,
+      tags: parseTags(payload?.tags),
+      quarantinedAt: new Date(),
+    }).save();
+
+    await this.auditService.record({
+      action: AuditAction.FILE_UPLOAD_QUARANTINED,
+      context,
+      target: { type: TARGET_TYPE, id: upload.id },
+      before: null,
+      after: {
+        storageArea: StorageArea.QUARANTINE,
+        status: UploadStatus.PENDING,
+        originalName: upload.originalName,
+        mimeType: upload.mimeType,
+        size: upload.size,
+        sha256: upload.sha256,
+      },
+    });
+
+    return this.toView(await this.scanAndSettle(upload, file.buffer, context));
+  }
+
+  /**
+   * Scans quarantined bytes and applies the verdict.
+   *
+   * - clean → moved to the clean area and released
+   * - infected → deleted, or moved to `infected/` when
+   *   `UPLOAD_RETAIN_INFECTED=true`
+   * - error → left in quarantine and unavailable (fails closed)
+   */
+  private async scanAndSettle(
+    upload: WorkerUploadDocument,
+    buffer: Buffer,
+    context: AuditContext,
+  ): Promise<WorkerUploadDocument> {
+    upload.status = UploadStatus.SCANNING;
+    await upload.save();
+
+    const result = await this.scanner.scan(buffer, upload.storageKey);
+    upload.scan = toScanRecord(result);
+
+    if (result.verdict === ScanVerdict.CLEAN) {
+      await this.storage.move(
+        upload.storageKey,
+        StorageArea.QUARANTINE,
+        StorageArea.CLEAN,
+      );
+      upload.storageArea = StorageArea.CLEAN;
+      upload.status = UploadStatus.CLEAN;
+      upload.releasedAt = new Date();
+    } else if (result.verdict === ScanVerdict.INFECTED) {
+      if (this.retainInfected) {
+        await this.storage.move(
+          upload.storageKey,
+          StorageArea.QUARANTINE,
+          StorageArea.INFECTED,
+        );
+        upload.storageArea = StorageArea.INFECTED;
+      } else {
+        await this.storage.remove(upload.storageKey, StorageArea.QUARANTINE);
+      }
+      upload.status = UploadStatus.INFECTED;
+    } else {
+      // No verdict: keep the bytes quarantined and unavailable.
+      upload.status = UploadStatus.ERROR;
+    }
+
+    await upload.save();
+
+    await this.auditService.record({
+      action: AuditAction.FILE_UPLOAD_SCANNED,
+      context,
+      target: { type: TARGET_TYPE, id: upload.id },
+      outcome:
+        result.verdict === ScanVerdict.CLEAN
+          ? AuditOutcome.SUCCESS
+          : AuditOutcome.FAILURE,
+      before: { status: UploadStatus.PENDING },
+      after: {
+        status: upload.status,
+        storageArea: upload.storageArea,
+        verdict: result.verdict,
+        signature: result.signature,
+        engine: result.engine,
+        sha256: upload.sha256,
+      },
+      reason: result.signature ?? result.details ?? null,
+    });
+
+    if (upload.status === UploadStatus.CLEAN) {
+      await this.auditService.record({
+        action: AuditAction.FILE_UPLOAD_RELEASED,
+        context,
+        target: { type: TARGET_TYPE, id: upload.id },
+        before: { status: UploadStatus.SCANNING },
+        after: { status: UploadStatus.CLEAN, storageArea: StorageArea.CLEAN },
+      });
+    }
+
+    return upload;
+  }
+
+  /** Metadata for a single upload. Owner or platform admin only. */
+  async getUpload(
+    id: string,
+    requesterId: string,
+    requesterRole?: string,
+  ): Promise<UploadView> {
+    return this.toView(await this.loadOwned(id, requesterId, requesterRole));
+  }
+
+  async listUploads(ownerId: string): Promise<UploadView[]> {
+    const uploads = await this.uploadModel
+      .find({ ownerId })
+      .sort({ createdAt: -1 })
+      .limit(100)
+      .exec();
+    return uploads.map((upload) => this.toView(upload));
+  }
+
+  /**
+   * Opens a read stream for a released file.
+   *
+   * Anything short of {@link UploadStatus.CLEAN} is refused with 409 — this is
+   * the check that makes "unavailable until scanned" real.
+   */
+  async openDownload(
+    id: string,
+    requesterId: string,
+    requesterRole?: string,
+  ): Promise<{ stream: ReadStream; upload: WorkerUploadDocument }> {
+    const upload = await this.loadOwned(id, requesterId, requesterRole);
+
+    if (!SERVABLE_STATUSES.includes(upload.status)) {
+      throw new ConflictException(
+        `File is not available for download (status: ${upload.status})`,
+      );
+    }
+
+    if (!(await this.storage.exists(upload.storageKey, StorageArea.CLEAN))) {
+      throw new NotFoundException('File contents are no longer available');
+    }
 
     return {
-      id: crypto.randomUUID(),
-      originalName: file.originalname,
-      filename: file.filename,
-      mimeType: file.mimetype,
-      size: file.size,
-      title: payload.title ?? null,
-      description: payload.description ?? null,
-      tags,
-      uploadedAt: new Date().toISOString(),
+      stream: this.storage.createReadStream(
+        upload.storageKey,
+        StorageArea.CLEAN,
+      ),
+      upload,
     };
   }
+
+  async deleteUpload(
+    id: string,
+    requesterId: string,
+    requesterRole?: string,
+    audit?: AuditContext,
+  ): Promise<{ id: string; deleted: boolean }> {
+    const upload = await this.loadOwned(id, requesterId, requesterRole);
+
+    await this.storage.remove(upload.storageKey, upload.storageArea);
+    await this.uploadModel.findByIdAndDelete(upload.id).exec();
+
+    await this.auditService.record({
+      action: AuditAction.FILE_UPLOAD_DELETED,
+      context: audit ?? systemAuditContext(),
+      target: { type: TARGET_TYPE, id: upload.id },
+      before: {
+        status: upload.status,
+        storageArea: upload.storageArea,
+        sha256: upload.sha256,
+      },
+      after: null,
+    });
+
+    return { id: upload.id, deleted: true };
+  }
+
+  private async loadOwned(
+    id: string,
+    requesterId: string,
+    requesterRole?: string,
+  ): Promise<WorkerUploadDocument> {
+    const upload = await this.uploadModel.findById(id).exec();
+    if (!upload) {
+      throw new NotFoundException('Upload not found');
+    }
+    if (upload.ownerId !== requesterId && requesterRole !== Role.ADMIN) {
+      // 404 rather than 403 so the endpoint does not confirm the id exists.
+      throw new NotFoundException('Upload not found');
+    }
+    return upload;
+  }
+
+  /** Rejects uploads that would breach the per-user storage or count quota. */
+  private async assertWithinQuota(
+    ownerId: string,
+    incomingBytes: number,
+  ): Promise<void> {
+    const windowMs = this.quotaWindowMs;
+    const since = new Date(Date.now() - windowMs);
+
+    const [countInWindow, aggregate] = await Promise.all([
+      this.uploadModel
+        .countDocuments({ ownerId, createdAt: { $gte: since } })
+        .exec(),
+      this.uploadModel
+        .aggregate<{
+          total: number;
+        }>([
+          { $match: { ownerId } },
+          { $group: { _id: null, total: { $sum: '$size' } } },
+        ])
+        .exec(),
+    ]);
+
+    if (countInWindow >= this.quotaMaxFiles) {
+      throw new ForbiddenException(
+        `Upload quota exceeded: at most ${this.quotaMaxFiles} files per ${Math.round(
+          windowMs / 1000,
+        )}s`,
+      );
+    }
+
+    const usedBytes = aggregate?.[0]?.total ?? 0;
+    if (usedBytes + incomingBytes > this.quotaMaxBytes) {
+      throw new ForbiddenException(
+        `Storage quota exceeded: at most ${this.quotaMaxBytes} bytes per user`,
+      );
+    }
+  }
+
+  private toView(upload: WorkerUploadDocument): UploadView {
+    const released = upload.status === UploadStatus.CLEAN;
+    return {
+      id: upload.id,
+      status: upload.status,
+      originalName: upload.originalName,
+      mimeType: upload.mimeType,
+      size: upload.size,
+      sha256: upload.sha256,
+      title: upload.title,
+      description: upload.description,
+      tags: upload.tags ?? [],
+      scan: upload.scan
+        ? {
+            verdict: upload.scan.verdict,
+            signature: upload.scan.signature,
+            engine: upload.scan.engine,
+            scannedAt: upload.scan.scannedAt,
+          }
+        : null,
+      downloadUrl: released
+        ? `/api/v1/worker/files/${upload.id}/content`
+        : null,
+      uploadedAt: (upload.createdAt ?? new Date()).toISOString(),
+    };
+  }
+
+  get maxFileBytes(): number {
+    return (
+      this.configService.get<number>('uploads.maxFileBytes') ?? 5 * 1024 * 1024
+    );
+  }
+
+  private get quotaMaxBytes(): number {
+    return (
+      this.configService.get<number>('uploads.quota.maxBytes') ??
+      100 * 1024 * 1024
+    );
+  }
+
+  private get quotaMaxFiles(): number {
+    return this.configService.get<number>('uploads.quota.maxFiles') ?? 20;
+  }
+
+  private get quotaWindowMs(): number {
+    return (
+      this.configService.get<number>('uploads.quota.windowMs') ??
+      24 * 60 * 60 * 1000
+    );
+  }
+
+  private get retainInfected(): boolean {
+    return this.configService.get<boolean>('uploads.retainInfected') === true;
+  }
+}
+
+export function parseTags(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .slice(0, 20);
+}
+
+function toScanRecord(result: ScanResult) {
+  return {
+    verdict: result.verdict,
+    signature: result.signature,
+    engine: result.engine,
+    scannedAt: result.scannedAt,
+    durationMs: result.durationMs,
+    details: result.details,
+  };
 }


### PR DESCRIPTION
Closes #853, Closes #854, Closes #855, Closes #856

## Summary

This PR resolves four critical security hardening issues across `chainVerse-backend`, establishing immutable audit logging, organization-scoped RBAC, worker upload endpoint hardening, and an asynchronous file quarantine & malware scanning pipeline.

---

## Key Changes

### 1. Immutable Audit Logging (#856)
- **`src/common/audit/`**: Implemented an append-only `AuditLog` collection tracking actor, role, action, target, request ID, timestamp, and redacted metadata.
- **Immutability & Tamper Detection**: Enforced three-layer immutability: Mongoose hooks blocking updates/deletions, a `pre('save')` guard preventing re-saves, and an HMAC integrity signature (`AUDIT_HMAC_SECRET` fallback to `JWT_SECRET`) to detect out-of-band database tampering.
- Integrated across `admin-course`, `admin-financial-aid-management`, `admin-auth`, `report-abuse`, `organization`, and `worker`.

### 2. Organization-Scoped Authorization Policies (#853)
- **`src/organization/` & `src/organization-member/`**: Introduced `OrganizationRole` (`owner`, `admin`, `instructor`, `member`) and `OrganizationRolesGuard`.
- Closed cross-tenant authorization leaks by scoping membership mutations strictly by tenant ID (`membershipParam` validation). Enforced protection rules around ownership transfer and last-owner safety.

### 3. Upload Endpoint Hardening (#854)
- **`src/worker/`**: Removed `@Public()` decorator from upload endpoints.
- **Validation**: Added file validation matching declared MIME types, file extensions, and header magic bytes.
- **Sanitization & Isolation**: Storage filenames are generated as cryptographically random UUIDs and saved completely outside the publicly served web directory tree.

### 4. Malware Scanning & Quarantine Lifecycle (#855)
- **Quarantine Pipeline**: Uploaded files land in `quarantine/` with status `PENDING_SCAN` and return `409 Conflict` if accessed before clean verification.
- **Scanner Backends**: Implemented dual scanner support (built-in EICAR/active-content heuristic scanner and ClamAV backend). Unscanned/infected files are deleted or retained in quarantine, generating audit security events.

---

## Verification

- [x] **Unit & Security Tests**: Added 219 new tests bringing the suite to 414 total tests.
- [x] **Cross-Tenant Access Checks**: Verified cross-organization denial tests (`403 Forbidden`) across organization membership endpoints.
- [x] **Documentation**: Added complete security docs under `docs/security/`, updated `.env.example`, and updated `README.md`.