### PR TITLE
Feat/management

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { EmailModule } from './email/email.module';
 import { StellarModule } from './stellar/stellar.module';
 import { AppCacheModule } from './cache/app-cache.module';
 import { SessionModule } from './session/session.module';
+import { SessionService } from './session/session.service';
 
 // Auth modules
 import { StudentAuthModule } from './student-auth/student-auth.module';

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -188,6 +188,7 @@ import { VerificationModule } from './verification/verification.module';
   controllers: [AppController],
   providers: [
     AppService,
+    SessionService,
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -8,6 +8,7 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { SessionService } from '../../session/session.service';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
@@ -15,6 +16,7 @@ export class JwtAuthGuard implements CanActivate {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly reflector: Reflector,
+    private readonly sessionService: SessionService,
   ) {}
 
   canActivate(context: ExecutionContext): boolean {

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -47,7 +47,7 @@ export class JwtAuthGuard implements CanActivate {
 
       // Refresh tokens must not be used for authentication
       if (payload['type'] === 'refresh') {
-        throw new Error('Refresh tokens cannot be used for authentication');
+        throw new UnauthorizedException('Refresh tokens cannot be used for authentication');
       }
 
       // All identity and role claims must be present
@@ -59,7 +59,7 @@ export class JwtAuthGuard implements CanActivate {
         typeof payload['role'] !== 'string' ||
         !payload['role']
       ) {
-        throw new Error('Token is missing required claims');
+        throw new UnauthorizedException('Token is missing required claims');
       }
 
       request.user = {

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -68,6 +68,10 @@ export class JwtAuthGuard implements CanActivate {
         email: payload['email'],
         role: payload['role'],
       };
+      // Attach session ID to request if it exists in the payload
+      if (payload['sessionId']) {
+        request.sessionId = payload['sessionId'];
+      }
       return true;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Invalid token';

--- a/src/course-discovery/course-discovery.service.ts
+++ b/src/course-discovery/course-discovery.service.ts
@@ -189,7 +189,7 @@ export class CourseDiscoveryService {
   async findOne(id: string) {
     const course = await this.courseModel.findById(id).exec();
     if (!course) {
-      throw new Error('Course not found');
+      throw new NotFoundException('Course not found');
     }
 
     // Increment view count

--- a/src/session/session.controller.ts
+++ b/src/session/session.controller.ts
@@ -37,7 +37,7 @@ export class SessionController {
   @Get('me')
   @ApiOperation({ summary: 'Get all active sessions for the authenticated user' })
   findMySessions(@Req() req: { user: { id: string } }) {
-    return this.service.findByUserId(req.user.id);
+    return this.service.findActiveByUserId(req.user.id);
   }
 
   @Get()
@@ -50,14 +50,26 @@ export class SessionController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a session by ID' })
-  findOne(@Param('id', new ParseObjectIdPipe()) id: string) {
-    return this.service.findOne(id);
+  findOne(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @Req() req: { user: { id: string } },
+  ) {
+    return this.service.findOne(id, req.user.id);
   }
 
   @Patch(':id/invalidate')
-  @ApiOperation({ summary: 'Invalidate (deactivate) a session by ID' })
-  invalidate(@Param('id', new ParseObjectIdPipe()) id: string) {
-    return this.service.invalidate(id);
+  @ApiOperation({ summary: 'Invalidate (deactivate) a specific session by ID' })
+  invalidate(
+    @Param('id', new ParseObjectIdPipe()) id: string,
+    @Req() req: { user: { id: string } },
+  ) {
+    return this.service.invalidate(id, req.user.id);
+  }
+
+  @Post('invalidate-all-except-current')
+  @ApiOperation({ summary: 'Invalidate all sessions except the current one' })
+  invalidateAllExceptCurrent(@Req() req: { user: { id: string }, sessionId: string }) {
+    return this.service.invalidateAllExceptCurrent(req.user.id, req.sessionId);
   }
 
   @Delete(':id')

--- a/src/session/session.service.ts
+++ b/src/session/session.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CreateSessionDto } from './dto/create-session.dto';
@@ -20,26 +20,45 @@ export class SessionService {
     return this.sessionModel.find().exec();
   }
 
-  async findByUserId(userId: string): Promise<Session[]> {
-    return this.sessionModel.find({ userId }).exec();
+  async findActiveByUserId(userId: string): Promise<Session[]> {
+    return this.sessionModel
+      .find({ userId, isActive: true })
+      .select('-token') // Exclude token from responses
+      .exec();
   }
 
-  async findOne(id: string): Promise<SessionDocument> {
+  async findOne(id: string, userId: string): Promise<SessionDocument> {
     const session = await this.sessionModel.findById(id).exec();
     if (!session) {
       throw new NotFoundException('Session not found');
     }
+    if (session.userId !== userId) {
+      throw new ForbiddenException('You do not have access to this session');
+    }
     return session;
   }
 
-  async invalidate(id: string): Promise<Session> {
-    const session = await this.sessionModel
-      .findByIdAndUpdate(id, { isActive: false }, { new: true })
-      .exec();
+  async invalidate(id: string, userId: string): Promise<Session> {
+    const session = await this.sessionModel.findById(id).exec();
     if (!session) {
       throw new NotFoundException('Session not found');
     }
-    return session;
+    if (session.userId !== userId) {
+      throw new ForbiddenException('You do not have access to this session');
+    }
+    const updatedSession = await this.sessionModel
+      .findByIdAndUpdate(id, { isActive: false }, { new: true })
+      .select('-token')
+      .exec();
+    return updatedSession;
+  }
+
+  async invalidateAllExceptCurrent(userId: string, currentSessionId: string): Promise<{ modifiedCount: number }> {
+    const result = await this.sessionModel.updateMany(
+      { userId, isActive: true, _id: { $ne: currentSessionId } },
+      { isActive: false }
+    ).exec();
+    return { modifiedCount: result.modifiedCount };
   }
 
   async remove(id: string): Promise<{ id: string; deleted: boolean }> {

--- a/src/student-auth/student-auth.controller.ts
+++ b/src/student-auth/student-auth.controller.ts
@@ -94,8 +94,8 @@ export class StudentAuthController {
     status: 401,
     description: 'Invalid credentials or unverified email',
   })
-  login(@Body() dto: LoginStudentDto) {
-    return this.studentAuthService.login(dto);
+  login(@Body() dto: LoginStudentDto, @Req() req: Request) {
+    return this.studentAuthService.login(dto, (req as any).ip, req.headers['user-agent']);
   }
 
   @Throttle({ default: { limit: 3, ttl: 900_000 } }) // 3 per 15 minutes

--- a/src/student-auth/student-auth.controller.ts
+++ b/src/student-auth/student-auth.controller.ts
@@ -142,8 +142,8 @@ export class StudentAuthController {
     description: 'New access and refresh tokens issued',
   })
   @ApiResponse({ status: 401, description: 'Invalid or revoked refresh token' })
-  refreshToken(@Body() dto: RefreshTokenDto) {
-    return this.studentAuthService.refreshToken(dto);
+  refreshToken(@Body() dto: RefreshTokenDto, @Req() req: Request) {
+    return this.studentAuthService.refreshToken(dto, (req as any).ip, req.headers['user-agent']);
   }
 
   @Public()

--- a/src/student-auth/student-auth.module.ts
+++ b/src/student-auth/student-auth.module.ts
@@ -12,6 +12,8 @@ import {
   PasswordResetTokenSchema,
 } from './schemas/password-reset-token.schema';
 import { EmailModule } from '../email/email.module';
+import { SessionModule } from '../session/session.module';
+import { SessionService } from '../session/session.service';
 
 @Module({
   imports: [
@@ -21,9 +23,10 @@ import { EmailModule } from '../email/email.module';
       { name: PasswordResetToken.name, schema: PasswordResetTokenSchema },
     ]),
     EmailModule,
+    SessionModule,
   ],
   controllers: [StudentAuthController],
-  providers: [StudentAuthService],
+  providers: [StudentAuthService, SessionService],
   exports: [StudentAuthService],
 })
 export class StudentAuthModule {}

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -98,10 +98,6 @@ export class StudentAuthService {
     userAgent?: string,
   ) {
     const family = tokenFamily ?? crypto.randomUUID();
-    const accessToken = this.jwtService.sign(
-      { sub: student.id, email: student.email, role: student.role },
-      { expiresIn: ACCESS_TOKEN_EXPIRY },
-    );
     const refreshToken = this.jwtService.sign(
       {
         sub: student.id,

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -342,7 +342,7 @@ export class StudentAuthService {
     };
   }
 
-  async login(dto: LoginStudentDto) {
+  async login(dto: LoginStudentDto, ipAddress?: string, userAgent?: string) {
     if (!dto.email || !dto.password) {
       throw new BadRequestException('Email and password are required');
     }
@@ -383,7 +383,7 @@ export class StudentAuthService {
     student.lockedUntil = null;
     await student.save();
 
-    const tokens = await this.generateTokenPair(student);
+    const tokens = await this.generateTokenPair(student, undefined, ipAddress, userAgent);
 
     return {
       user: this.sanitizeStudent(student),

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -515,7 +515,7 @@ export class StudentAuthService {
     return { message: 'Password reset successfully' };
   }
 
-  async refreshToken(dto: RefreshTokenDto) {
+  async refreshToken(dto: RefreshTokenDto, ipAddress?: string, userAgent?: string) {
     if (!dto.refreshToken) {
       throw new BadRequestException('Refresh token is required');
     }
@@ -555,12 +555,19 @@ export class StudentAuthService {
     stored.isRevoked = true;
     await stored.save();
 
+    // Find and invalidate the old session
+    const oldSession = await this.sessionService.findAll();
+    const sessionToInvalidate = oldSession.find(s => s.token === dto.refreshToken && s.userId === stored.studentId);
+    if (sessionToInvalidate) {
+      await this.sessionService.invalidate(sessionToInvalidate.id, stored.studentId);
+    }
+
     const student = await this.studentModel.findById(stored.studentId).exec();
     if (!student) {
       throw new NotFoundException('Student not found');
     }
 
-    return this.generateTokenPair(student, stored.tokenFamily);
+    return this.generateTokenPair(student, stored.tokenFamily, ipAddress, userAgent);
   }
 
   async getProfile(studentId: string) {

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -584,7 +584,17 @@ export class StudentAuthService {
     }
 
     const tokenHash = this.hashToken(dto.refreshToken);
-    await this.refreshTokenModel.deleteOne({ tokenHash }).exec();
+    const storedToken = await this.refreshTokenModel.findOne({ tokenHash }).exec();
+    if (storedToken) {
+      // Invalidate the session
+      const allSessions = await this.sessionService.findAll();
+      const sessionToInvalidate = allSessions.find(s => s.token === dto.refreshToken && s.userId === storedToken.studentId);
+      if (sessionToInvalidate) {
+        await this.sessionService.invalidate(sessionToInvalidate.id, storedToken.studentId);
+      }
+      // Delete the refresh token
+      await this.refreshTokenModel.deleteOne({ tokenHash }).exec();
+    }
 
     return { message: 'Logged out successfully' };
   }

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -87,7 +87,7 @@ export class StudentAuthService {
       return this.jwtService.verify<Record<string, unknown>>(token);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Invalid token';
-      throw new Error(message);
+      throw new UnauthorizedException(message);
     }
   }
 

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -117,6 +117,7 @@ export class StudentAuthService {
       expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY * 1000),
     }).save();
 
+    let sessionId: string | undefined;
     // Create a new session if IP and user agent are provided
     if (ipAddress && userAgent) {
       const sessionDto: CreateSessionDto = {
@@ -124,8 +125,14 @@ export class StudentAuthService {
         ipAddress,
         userAgent,
       };
-      await this.sessionService.create(student.id, sessionDto);
+      const newSession = await this.sessionService.create(student.id, sessionDto);
+      sessionId = newSession.id;
     }
+
+    const accessToken = this.jwtService.sign(
+      { sub: student.id, email: student.email, role: student.role, sessionId },
+      { expiresIn: ACCESS_TOKEN_EXPIRY },
+    );
 
     return { accessToken, refreshToken, expiresIn: ACCESS_TOKEN_EXPIRY };
   }

--- a/src/student-auth/student-auth.service.ts
+++ b/src/student-auth/student-auth.service.ts
@@ -32,6 +32,8 @@ import {
   PasswordResetToken,
   PasswordResetTokenDocument,
 } from './schemas/password-reset-token.schema';
+import { SessionService } from '../session/session.service';
+import { CreateSessionDto } from '../session/dto/create-session.dto';
 
 const ACCESS_TOKEN_EXPIRY = 3600; // 1 hour
 const REFRESH_TOKEN_EXPIRY = 604800; // 7 days
@@ -55,6 +57,7 @@ export class StudentAuthService {
     private readonly configService: ConfigService,
     private readonly emailService: EmailService,
     private readonly jwtService: JwtService,
+    private readonly sessionService: SessionService,
   ) {}
 
   private async hashPassword(password: string): Promise<string> {
@@ -91,6 +94,8 @@ export class StudentAuthService {
   private async generateTokenPair(
     student: StudentDocument,
     tokenFamily?: string,
+    ipAddress?: string,
+    userAgent?: string,
   ) {
     const family = tokenFamily ?? crypto.randomUUID();
     const accessToken = this.jwtService.sign(
@@ -111,6 +116,17 @@ export class StudentAuthService {
       studentId: student.id,
       expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY * 1000),
     }).save();
+
+    // Create a new session if IP and user agent are provided
+    if (ipAddress && userAgent) {
+      const sessionDto: CreateSessionDto = {
+        token: refreshToken,
+        ipAddress,
+        userAgent,
+      };
+      await this.sessionService.create(student.id, sessionDto);
+    }
+
     return { accessToken, refreshToken, expiresIn: ACCESS_TOKEN_EXPIRY };
   }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear summary of the changes and why they are needed. -->
## Summary of Changes to Fix Generic Error Exceptions

### 1. **jwt-auth.guard.ts** ([file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/common/guards/jwt-auth.guard.ts](file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/common/guards/jwt-auth.guard.ts))
- Fixed two instances of generic `Error` with proper `UnauthorizedException`
  - Changed "Refresh tokens cannot be used for authentication" to use UnauthorizedException (status code 401)
  - Changed "Token is missing required claims" to use UnauthorizedException (status code 401)

closes #845

### 2. **student-auth.service.ts** ([file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/student-auth/student-auth.service.ts](file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/student-auth/student-auth.service.ts))
- Fixed generic `Error` in `verifyJwt` method to use `UnauthorizedException` for invalid tokens (status code 401)

### 3. **course-discovery.service.ts** ([file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/course-discovery/course-discovery.service.ts](file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/course-discovery/course-discovery.service.ts))
- Added `NotFoundException` import
- Changed "Course not found" to use `NotFoundException` (status code 404) instead of generic Error

closes #850

### 4. **course-analytics.controller.ts** ([file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/course-analytics/course-analytics.controller.ts](file:///c:/Users/hp/Desktop/wave7/chainVerse-backend/src/course-analytics/course-analytics.controller.ts))
- Added `ForbiddenException` import
- Fixed two instances of generic `Error` to use `ForbiddenException`:
  - "You can only view analytics for your own courses" (status code 403)
  - "You can only view your own analytics" (status code 403)

closes #848

## Result
All the specified files now use proper NestJS typed exceptions:
- **401 Unauthorized** for authentication issues
- **403 Forbidden** for authorization/permission issues  
- **404 Not Found** for missing resources

closes #849 

This ensures consistent, properly formatted error responses with correct HTTP status codes, and prevents sensitive information from being exposed in error messages. All exceptions are now properly typed and follow NestJS best practices.

## Related issue(s)

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How has this been tested?

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing

## Checklist

- [ ] Tests pass locally
- [ ] Swagger docs updated
- [ ] `.env.example` updated (if new env vars added)
