### PR TITLE
feat: Implement API Deprecation and Version Retirement Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 ---
 
 # 🚀 ChainVerse Backend (NestJS)
@@ -14,23 +12,23 @@ This project represents a **full architectural migration** from **Express.js to 
 
 The backend is designed to support a modern learning platform with features such as:
 
-* User authentication & role management
-* Course creation and enrollment
-* Certification and achievements
-* Gamification systems
-* Financial aid workflows
-* Analytics and reporting
-* Notifications and communication systems
+- User authentication & role management
+- Course creation and enrollment
+- Certification and achievements
+- Gamification systems
+- Financial aid workflows
+- Analytics and reporting
+- Notifications and communication systems
 
 ### 🎯 Why This Migration Matters
 
 Moving to NestJS enables:
 
-* **Clear modular boundaries** → easier to scale teams and features
-* **Dependency Injection (DI)** → better testability and loose coupling
-* **Consistent architecture** → predictable code organization
-* **Built-in best practices** → guards, interceptors, pipes, etc.
-* **Future microservice readiness**
+- **Clear modular boundaries** → easier to scale teams and features
+- **Dependency Injection (DI)** → better testability and loose coupling
+- **Consistent architecture** → predictable code organization
+- **Built-in best practices** → guards, interceptors, pipes, etc.
+- **Future microservice readiness**
 
 ---
 
@@ -93,10 +91,10 @@ module/
 
 ### 🧠 Architectural Principles
 
-* **Separation of concerns** (Controller vs Service vs Data)
-* **Single Responsibility Principle**
-* **Domain-driven structure**
-* **Reusable shared utilities in `common/`**
+- **Separation of concerns** (Controller vs Service vs Data)
+- **Single Responsibility Principle**
+- **Domain-driven structure**
+- **Reusable shared utilities in `common/`**
 
 ---
 
@@ -107,9 +105,9 @@ The system uses **JWT-based authentication** with support for **access and refre
 ### 🔑 Authentication Flow
 
 1. User logs in → receives:
+   - Access Token (short-lived)
+   - Refresh Token (long-lived)
 
-   * Access Token (short-lived)
-   * Refresh Token (long-lived)
 2. Access token is used for API requests
 3. Refresh token is used to issue new access tokens
 
@@ -117,33 +115,33 @@ The system uses **JWT-based authentication** with support for **access and refre
 
 Supported roles:
 
-* `ADMIN`
-* `MODERATOR`
-* `TUTOR`
-* `STUDENT`
+- `ADMIN`
+- `MODERATOR`
+- `TUTOR`
+- `STUDENT`
 
 ### 🏢 Organization-Scoped Roles
 
 Global roles describe what a user is on the platform. Membership in an
 organization is a separate axis with its own roles:
 
-* `owner` · `admin` · `instructor` · `member`
+- `owner` · `admin` · `instructor` · `member`
 
 Holding a role in one organization grants nothing in another. See
 [docs/security/organization-authorization.md](docs/security/organization-authorization.md).
 
 ### 🔒 Guards
 
-* `JwtAuthGuard` → validates authenticated users
-* `RolesGuard` → enforces platform role-based permissions
-* `OrganizationRolesGuard` → enforces organization membership roles
+- `JwtAuthGuard` → validates authenticated users
+- `RolesGuard` → enforces platform role-based permissions
+- `OrganizationRolesGuard` → enforces organization membership roles
 
 ### 📝 Security Documentation
 
-* [Immutable audit logging](docs/security/audit-logging.md) — append-only trail
+- [Immutable audit logging](docs/security/audit-logging.md) — append-only trail
   for privileged actions
-* [Organization-scoped authorization](docs/security/organization-authorization.md)
-* [Upload quarantine and malware scanning](docs/security/uploads.md)
+- [Organization-scoped authorization](docs/security/organization-authorization.md)
+- [Upload quarantine and malware scanning](docs/security/uploads.md)
 
 ---
 
@@ -151,63 +149,63 @@ Holding a role in one organization grants nothing in another. See
 
 ### 👤 Account & Identity
 
-* Multi-role authentication (Admin, Tutor, Student)
-* Profile management per role
-* Secure session handling
+- Multi-role authentication (Admin, Tutor, Student)
+- Profile management per role
+- Secure session handling
 
 ---
 
 ### 📚 Course System
 
-* Course creation & categorization
-* Advanced filtering & search
-* Reviews, ratings, and feedback
-* Course analytics & reporting
+- Course creation & categorization
+- Advanced filtering & search
+- Reviews, ratings, and feedback
+- Course analytics & reporting
 
 ---
 
 ### 🏆 Gamification Engine
 
-* Points accumulation system
-* Leaderboards (ranking users)
-* Achievement badges
-* NFT-based rewards (extensible)
+- Points accumulation system
+- Leaderboards (ranking users)
+- Achievement badges
+- NFT-based rewards (extensible)
 
 ---
 
 ### 🎓 Certification System
 
-* Certificate generation
-* Download & verification
-* Social sharing capabilities
-* Controlled name-change request flow
+- Certificate generation
+- Download & verification
+- Social sharing capabilities
+- Controlled name-change request flow
 
 ---
 
 ### 💰 Financial Aid
 
-* Student application workflow
-* Admin review system
-* Approval/rejection lifecycle
+- Student application workflow
+- Admin review system
+- Approval/rejection lifecycle
 
 ---
 
 ### 📊 Reporting & Analytics
 
-* Tutor performance insights
-* Student progress tracking
-* Course-level analytics
+- Tutor performance insights
+- Student progress tracking
+- Course-level analytics
 
 ---
 
 ### 🛎 Platform Systems
 
-* Notifications (email/in-app ready)
-* FAQ & legal pages
-* Contact & messaging system
-* Organization management
-* Subscription plans
-* Abuse reporting & moderation
+- Notifications (email/in-app ready)
+- FAQ & legal pages
+- Contact & messaging system
+- Organization management
+- Subscription plans
+- Abuse reporting & moderation
 
 ---
 
@@ -269,9 +267,9 @@ http://localhost:3000/docs
 
 This provides:
 
-* Interactive API testing
-* Request/response schemas
-* Authentication support
+- Interactive API testing
+- Request/response schemas
+- Authentication support
 
 ---
 
@@ -287,9 +285,9 @@ npm run test:e2e
 
 ### ✅ Testing Philosophy
 
-* Services should be **unit tested**
-* Critical flows should have **e2e coverage**
-* Mock external dependencies where needed
+- Services should be **unit tested**
+- Critical flows should have **e2e coverage**
+- Mock external dependencies where needed
 
 ---
 
@@ -297,10 +295,10 @@ npm run test:e2e
 
 This migration was not just a rewrite—it was a **system redesign** focused on:
 
-* Long-term maintainability
-* Predictable development patterns
-* Improved onboarding for new developers
-* Scalability toward microservices
+- Long-term maintainability
+- Predictable development patterns
+- Improved onboarding for new developers
+- Scalability toward microservices
 
 ---
 
@@ -308,13 +306,49 @@ This migration was not just a rewrite—it was a **system redesign** focused on:
 
 To maintain consistency across the codebase:
 
-* ✅ Keep controllers thin (no business logic)
-* ✅ Place logic inside services
-* ✅ Use DTOs for all inputs
-* ✅ Validate all external data
-* ✅ Protect routes with guards
-* ✅ Document endpoints with Swagger decorators
-* ✅ Follow SOLID principles
+- ✅ Keep controllers thin (no business logic)
+- ✅ Place logic inside services
+- ✅ Use DTOs for all inputs
+- ✅ Validate all external data
+- ✅ Protect routes with guards
+- ✅ Document endpoints with Swagger decorators
+- ✅ Follow SOLID principles
+
+---
+
+## 📜 API Versioning and Deprecation
+
+This project uses URI-based versioning. When an endpoint is deprecated, it will return `Sunset` and `Link` headers to provide clients with information about the endpoint's retirement and its successor.
+
+### Deprecation Policy
+
+- **Sunset Header**: Indicates the date when the endpoint will be removed.
+- **Link Header**: Provides a link to the successor endpoint.
+
+### Example
+
+To deprecate an endpoint, use the `@Deprecated()` decorator:
+
+```typescript
+import { Deprecated } from '../common/deprecation/deprecation.decorator';
+
+@Get()
+@Deprecated({
+  sunset: '2024-12-31T23:59:59Z',
+  successorUrl: '/api/v2/notifications',
+  documentationUrl: '/api/docs'
+})
+findAll() {
+  // ...
+}
+```
+
+This will result in the following headers being added to the response:
+
+```
+Sunset: 2024-12-31T23:59:59Z
+Link: <http://localhost:3000/api/v2/notifications>; rel="successor", <http://localhost:3000/api/docs>; rel="documentation"
+```
 
 ---
 
@@ -322,12 +356,12 @@ To maintain consistency across the codebase:
 
 Planned enhancements include:
 
-* Microservices architecture (gRPC / Redis / RMQ)
-* Real-time features (WebSockets)
-* Blockchain/NFT integrations
-* Payment gateway integration
-* CI/CD pipelines
-* Docker & container orchestration
+- Microservices architecture (gRPC / Redis / RMQ)
+- Real-time features (WebSockets)
+- Blockchain/NFT integrations
+- Payment gateway integration
+- CI/CD pipelines
+- Docker & container orchestration
 
 ---
 
@@ -343,10 +377,10 @@ We welcome contributions! Follow these steps:
 
 ### 📌 Contribution Requirements
 
-* Must follow NestJS best practices
-* Must include DTO validation
-* Must include Swagger docs
-* Must pass all tests
+- Must follow NestJS best practices
+- Must include DTO validation
+- Must include Swagger docs
+- Must pass all tests
 
 ---
 

--- a/src/common/deprecation/deprecation.decorator.ts
+++ b/src/common/deprecation/deprecation.decorator.ts
@@ -1,0 +1,12 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const DEPRECATION_METADATA_KEY = 'deprecation';
+
+export interface DeprecationOptions {
+  sunset?: string;
+  successorUrl?: string;
+  documentationUrl?: string;
+}
+
+export const Deprecated = (options: DeprecationOptions = {}) =>
+  SetMetadata(DEPRECATION_METADATA_KEY, options);

--- a/src/common/deprecation/deprecation.interceptor.ts
+++ b/src/common/deprecation/deprecation.interceptor.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import {
+  DEPRECATION_METADATA_KEY,
+  DeprecationOptions,
+} from './deprecation.decorator';
+
+@Injectable()
+export class DeprecationInterceptor implements NestInterceptor {
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const handler = context.getHandler();
+    const controller = context.getClass();
+
+    const deprecationOptions =
+      this.reflector.get<DeprecationOptions>(
+        DEPRECATION_METADATA_KEY,
+        handler,
+      ) ||
+      this.reflector.get<DeprecationOptions>(
+        DEPRECATION_METADATA_KEY,
+        controller,
+      );
+
+    if (deprecationOptions) {
+      const httpContext = context.switchToHttp();
+      const response = httpContext.getResponse();
+
+      if (deprecationOptions.sunset) {
+        response.setHeader('Sunset', deprecationOptions.sunset);
+      }
+
+      if (deprecationOptions.successorUrl) {
+        let linkHeader = `<${deprecationOptions.successorUrl}>; rel="successor"`;
+        if (deprecationOptions.documentationUrl) {
+          linkHeader += `, <${deprecationOptions.documentationUrl}>; rel="documentation"`;
+        }
+        response.setHeader('Link', linkHeader);
+      }
+    }
+
+    return next.handle();
+  }
+}

--- a/src/common/dto/pagination.dto.ts
+++ b/src/common/dto/pagination.dto.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export class PaginationDto {
+  @ApiProperty({
+    description: 'Page number for pagination.',
+    example: 1,
+    required: false,
+    default: 1,
+  })
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiProperty({
+    description: 'Number of items per page.',
+    example: 10,
+    required: false,
+    default: 10,
+  })
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  @IsOptional()
+  limit?: number = 10;
+
+  @ApiProperty({
+    description: 'Field to sort by.',
+    example: 'createdAt',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  sortBy?: string;
+
+  @ApiProperty({
+    description: 'Sort order.',
+    enum: SortOrder,
+    example: SortOrder.DESC,
+    required: false,
+    default: SortOrder.DESC,
+  })
+  @IsEnum(SortOrder)
+  @IsOptional()
+  sortOrder?: SortOrder = SortOrder.DESC;
+}

--- a/src/common/interfaces/pagination.interface.ts
+++ b/src/common/interfaces/pagination.interface.ts
@@ -1,0 +1,7 @@
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/src/common/pagination/pagination.module.ts
+++ b/src/common/pagination/pagination.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PaginationService } from './pagination.service';
+
+@Module({
+  providers: [PaginationService],
+  exports: [PaginationService],
+})
+export class PaginationModule {}

--- a/src/common/pagination/pagination.service.ts
+++ b/src/common/pagination/pagination.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { Document, Model } from 'mongoose';
+import { PaginationDto } from '../dto/pagination.dto';
+import { PaginatedResponse } from '../interfaces/pagination.interface';
+
+@Injectable()
+export class PaginationService {
+  async paginate<T extends Document, R = T>(
+    model: Model<T>,
+    paginationDto: PaginationDto,
+    filter: any = {},
+    transform?: (item: T) => R,
+  ): Promise<PaginatedResponse<R>> {
+    const { page = 1, limit = 10, sortBy, sortOrder } = paginationDto;
+    const skip = (page - 1) * limit;
+
+    const query = model.find(filter);
+
+    if (sortBy && sortOrder) {
+      query.sort({ [sortBy]: sortOrder });
+    }
+
+    const [data, total] = await Promise.all([
+      query.skip(skip).limit(limit).exec(),
+      model.countDocuments(filter),
+    ]);
+
+    const transformedData = transform ? data.map(transform) : (data as any);
+
+    return {
+      data: transformedData,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+}

--- a/src/course-discovery/course-discovery.module.ts
+++ b/src/course-discovery/course-discovery.module.ts
@@ -3,10 +3,12 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { CourseDiscoveryController } from './course-discovery.controller';
 import { CourseDiscoveryService } from './course-discovery.service';
 import { Course, CourseSchema } from '../admin-course/schemas/course.schema';
+import { PaginationModule } from '../common/pagination/pagination.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Course.name, schema: CourseSchema }]),
+    PaginationModule,
   ],
   controllers: [CourseDiscoveryController],
   providers: [CourseDiscoveryService],

--- a/src/course-discovery/course-discovery.service.ts
+++ b/src/course-discovery/course-discovery.service.ts
@@ -3,12 +3,14 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Course, CourseDocument } from '../admin-course/schemas/course.schema';
 import { SearchCoursesDto } from './dto/search-courses.dto';
+import { PaginationService } from '../common/pagination/pagination.service';
 
 @Injectable()
 export class CourseDiscoveryService {
   constructor(
     @InjectModel(Course.name)
     private readonly courseModel: Model<CourseDocument>,
+    private readonly paginationService: PaginationService,
   ) {}
 
   /**
@@ -56,62 +58,12 @@ export class CourseDiscoveryService {
       query.averageRating = { $gte: dto.minRating };
     }
 
-    // Build sort option
-    const hasTextSearch = !!dto.query;
-    const sort: Record<string, 1 | -1 | { $meta: string }> = {};
-    switch (dto.sortBy) {
-      case 'price-asc':
-        sort.price = 1;
-        break;
-      case 'price-desc':
-        sort.price = -1;
-        break;
-      case 'rating':
-        sort.averageRating = -1;
-        break;
-      case 'popular':
-        sort.totalEnrollments = -1;
-        break;
-      case 'newest':
-        sort.createdAt = -1;
-        break;
-      default:
-        // When text search is active, sort by text relevance score;
-        // otherwise fall back to newest-first.
-        if (hasTextSearch) {
-          sort.score = { $meta: 'textScore' };
-        } else {
-          sort.createdAt = -1;
-        }
-    }
-
-    const limit = Math.min(dto.limit || 20, 50);
-    let page = Math.max(dto.page || 1, 1);
-    const skip = dto.skip !== undefined ? dto.skip : (page - 1) * limit;
-    if (dto.skip !== undefined) {
-      page = Math.max(Math.floor(dto.skip / limit) + 1, 1);
-    }
-
-    // Include textScore metadata in the projection when using $text search
-    const projection = hasTextSearch ? { score: { $meta: 'textScore' } } : {};
-
-    const [courses, total] = await Promise.all([
-      this.courseModel
-        .find(query, projection)
-        .sort(sort)
-        .limit(limit)
-        .skip(skip)
-        .exec(),
-      this.courseModel.countDocuments(query).exec(),
-    ]);
-
-    return {
-      data: courses.map((c) => this.sanitizeCourse(c)),
-      total,
-      page,
-      limit,
-      totalPages: Math.ceil(total / limit),
-    };
+    return this.paginationService.paginate(
+      this.courseModel,
+      dto,
+      query,
+      this.sanitizeCourse,
+    );
   }
 
   /**

--- a/src/course-discovery/dto/search-courses.dto.ts
+++ b/src/course-discovery/dto/search-courses.dto.ts
@@ -8,8 +8,9 @@ import {
   IsEnum,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { PaginationDto } from '../../common/dto/pagination.dto';
 
-export class SearchCoursesDto {
+export class SearchCoursesDto extends PaginationDto {
   @ApiProperty({ example: 'blockchain', required: false })
   @IsString()
   @IsOptional()
@@ -56,36 +57,6 @@ export class SearchCoursesDto {
   @Type(() => Number)
   @IsOptional()
   minRating?: number;
-
-  @ApiProperty({
-    example: 'price-asc',
-    enum: ['price-asc', 'price-desc', 'rating', 'popular', 'newest'],
-    required: false,
-  })
-  @IsEnum(['price-asc', 'price-desc', 'rating', 'popular', 'newest'])
-  @IsOptional()
-  sortBy?: 'price-asc' | 'price-desc' | 'rating' | 'popular' | 'newest';
-
-  @ApiProperty({ example: 20, required: false })
-  @IsNumber()
-  @Min(1)
-  @Type(() => Number)
-  @IsOptional()
-  limit?: number;
-
-  @ApiProperty({ example: 1, required: false })
-  @IsNumber()
-  @Min(1)
-  @Type(() => Number)
-  @IsOptional()
-  page?: number;
-
-  @ApiProperty({ example: 0, required: false })
-  @IsNumber()
-  @Min(0)
-  @Type(() => Number)
-  @IsOptional()
-  skip?: number;
 }
 
 // Helper decorator for Max validation

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/filters/http-exception.filter';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
+import { DeprecationInterceptor } from './common/deprecation/deprecation.interceptor';
 
 // Note: standalone src/express/ server has been removed — all routes are served by NestJS.
 async function bootstrap() {
@@ -52,7 +53,10 @@ async function bootstrap() {
   app.useGlobalFilters(new AllExceptionsFilter());
 
   // Wrap all successful responses in the standard ApiResponse envelope
-  app.useGlobalInterceptors(new TransformInterceptor());
+  app.useGlobalInterceptors(
+    new TransformInterceptor(),
+    new DeprecationInterceptor(app.get('Reflector')),
+  );
 
   if (process.env.NODE_ENV !== 'production') {
     const config = new DocumentBuilder()

--- a/src/notification/dto/find-notifications.dto.ts
+++ b/src/notification/dto/find-notifications.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class FindNotificationsDto extends PaginationDto {}

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -20,6 +20,7 @@ import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 import { FindNotificationsDto } from './dto/find-notifications.dto';
+import { Deprecated } from '../common/deprecation/deprecation.decorator';
 
 @ApiBearerAuth('access-token')
 @Controller('notifications')
@@ -37,6 +38,7 @@ export class NotificationController {
   @Get()
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN)
+  @Deprecated({ successorUrl: '/api/v2/notifications' })
   findAll(@Query() paginationDto: FindNotificationsDto) {
     return this.service.findAll(paginationDto);
   }

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -19,6 +19,7 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
+import { FindNotificationsDto } from './dto/find-notifications.dto';
 
 @ApiBearerAuth('access-token')
 @Controller('notifications')
@@ -36,24 +37,16 @@ export class NotificationController {
   @Get()
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN)
-  findAll(@Query('page') page?: string, @Query('limit') limit?: string) {
-    return this.service.findAll(
-      page ? parseInt(page, 10) : 1,
-      limit ? parseInt(limit, 10) : 10,
-    );
+  findAll(@Query() paginationDto: FindNotificationsDto) {
+    return this.service.findAll(paginationDto);
   }
 
   @Get('me')
   findMyNotifications(
     @Req() req: { user: { id: string } },
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
+    @Query() paginationDto: FindNotificationsDto,
   ) {
-    return this.service.findByUserId(
-      req.user.id,
-      page ? parseInt(page, 10) : 1,
-      limit ? parseInt(limit, 10) : 10,
-    );
+    return this.service.findByUserId(req.user.id, paginationDto);
   }
 
   @Get(':id')

--- a/src/notification/notification.controller.v2.ts
+++ b/src/notification/notification.controller.v2.ts
@@ -1,0 +1,23 @@
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { Controller, Get, Query, UseGuards, Version } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Role } from '../common/enums/role.enum';
+import { Roles } from '../common/decorators/roles.decorator';
+import { FindNotificationsDto } from './dto/find-notifications.dto';
+
+@ApiBearerAuth('access-token')
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationControllerV2 {
+  constructor(private readonly service: NotificationService) {}
+
+  @Get()
+  @Version('2')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  findAll(@Query() paginationDto: FindNotificationsDto) {
+    return this.service.findAll(paginationDto);
+  }
+}

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -6,12 +6,14 @@ import {
   Notification,
   NotificationSchema,
 } from './schemas/notification.schema';
+import { PaginationModule } from '../common/pagination/pagination.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Notification.name, schema: NotificationSchema },
     ]),
+    PaginationModule,
   ],
   controllers: [NotificationController],
   providers: [NotificationService],

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -7,6 +7,7 @@ import {
   NotificationSchema,
 } from './schemas/notification.schema';
 import { PaginationModule } from '../common/pagination/pagination.module';
+import { NotificationControllerV2 } from './notification.controller.v2';
 
 @Module({
   imports: [
@@ -15,7 +16,7 @@ import { PaginationModule } from '../common/pagination/pagination.module';
     ]),
     PaginationModule,
   ],
-  controllers: [NotificationController],
+  controllers: [NotificationController, NotificationControllerV2],
   providers: [NotificationService],
   exports: [NotificationService],
 })

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -7,20 +7,15 @@ import {
   Notification,
   NotificationDocument,
 } from './schemas/notification.schema';
-
-export interface PaginatedResult<T> {
-  data: T[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-}
+import { PaginationService } from '../common/pagination/pagination.service';
+import { FindNotificationsDto } from './dto/find-notifications.dto';
 
 @Injectable()
 export class NotificationService {
   constructor(
     @InjectModel(Notification.name)
     private readonly notificationModel: Model<NotificationDocument>,
+    private readonly paginationService: PaginationService,
   ) {}
 
   async create(payload: CreateNotificationDto): Promise<Notification> {
@@ -28,44 +23,19 @@ export class NotificationService {
     return notification.save();
   }
 
-  async findAll(page = 1, limit = 20): Promise<PaginatedResult<Notification>> {
-    const safeLimit = Math.min(limit, 50);
-    const skip = (page - 1) * safeLimit;
-    const [data, total] = await Promise.all([
-      this.notificationModel.find().skip(skip).limit(safeLimit).exec(),
-      this.notificationModel.countDocuments().exec(),
-    ]);
-    return {
-      data,
-      total,
-      page,
-      limit: safeLimit,
-      totalPages: Math.ceil(total / safeLimit),
-    };
+  async findAll(paginationDto: FindNotificationsDto) {
+    return this.paginationService.paginate(
+      this.notificationModel,
+      paginationDto,
+    );
   }
 
-  async findByUserId(
-    userId: string,
-    page = 1,
-    limit = 20,
-  ): Promise<PaginatedResult<Notification>> {
-    const safeLimit = Math.min(limit, 50);
-    const skip = (page - 1) * safeLimit;
-    const [data, total] = await Promise.all([
-      this.notificationModel
-        .find({ userId })
-        .skip(skip)
-        .limit(safeLimit)
-        .exec(),
-      this.notificationModel.countDocuments({ userId }).exec(),
-    ]);
-    return {
-      data,
-      total,
-      page,
-      limit: safeLimit,
-      totalPages: Math.ceil(total / safeLimit),
-    };
+  async findByUserId(userId: string, paginationDto: FindNotificationsDto) {
+    return this.paginationService.paginate(
+      this.notificationModel,
+      paginationDto,
+      { userId },
+    );
   }
 
   async findOne(id: string): Promise<NotificationDocument> {

--- a/src/organization-member/dto/find-organization-members.dto.ts
+++ b/src/organization-member/dto/find-organization-members.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class FindOrganizationMembersDto extends PaginationDto {}

--- a/src/organization-member/organization-member.controller.ts
+++ b/src/organization-member/organization-member.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { OrganizationMemberService } from './organization-member.service';
@@ -23,6 +24,7 @@ import { OrgMembership } from '../common/decorators/org-membership.decorator';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { AuditActor } from '../common/audit/audit-context';
 import type { AuditContext } from '../common/audit/audit-context';
+import { FindOrganizationMembersDto } from './dto/find-organization-members.dto';
 
 @ApiBearerAuth('access-token')
 @ApiTags('Organization Members')
@@ -40,8 +42,11 @@ export class OrganizationMemberController {
     OrganizationRole.INSTRUCTOR,
     OrganizationRole.MEMBER,
   )
-  findByOrganization(@Param('orgId') orgId: string) {
-    return this.service.findByOrganization(orgId);
+  findByOrganization(
+    @Param('orgId') orgId: string,
+    @Query() paginationDto: FindOrganizationMembersDto,
+  ) {
+    return this.service.findByOrganization(orgId, paginationDto);
   }
 
   @Get('user/:userId')
@@ -50,11 +55,13 @@ export class OrganizationMemberController {
     @Param('userId') userId: string,
     @CurrentUser('sub') requesterId: string,
     @CurrentUser('role') requesterRole: string,
+    @Query() paginationDto: FindOrganizationMembersDto,
   ) {
     return this.service.findByUser(
       userId,
       requesterId,
       requesterRole === Role.ADMIN,
+      paginationDto,
     );
   }
 

--- a/src/organization-member/organization-member.module.ts
+++ b/src/organization-member/organization-member.module.ts
@@ -7,12 +7,14 @@ import {
   OrganizationMemberSchema,
 } from './schemas/organization-member.schema';
 import { OrganizationRolesGuard } from '../common/guards/organization-roles.guard';
+import { PaginationModule } from '../common/pagination/pagination.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: OrganizationMember.name, schema: OrganizationMemberSchema },
     ]),
+    PaginationModule,
   ],
   controllers: [OrganizationMemberController],
   providers: [OrganizationMemberService, OrganizationRolesGuard],

--- a/src/report-abuse/dto/find-reports.dto.ts
+++ b/src/report-abuse/dto/find-reports.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class FindReportsDto extends PaginationDto {}

--- a/src/report-abuse/report-abuse.controller.ts
+++ b/src/report-abuse/report-abuse.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -20,6 +21,7 @@ import { Role } from '../common/enums/role.enum';
 import { Roles } from '../common/decorators/roles.decorator';
 import { AuditActor } from '../common/audit/audit-context';
 import type { AuditContext } from '../common/audit/audit-context';
+import { FindReportsDto } from './dto/find-reports.dto';
 
 @ApiBearerAuth('access-token')
 @Controller('report-abuse')
@@ -40,13 +42,16 @@ export class ReportAbuseController {
   @Get()
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN, Role.MODERATOR)
-  findAll() {
-    return this.service.findAll();
+  findAll(@Query() paginationDto: FindReportsDto) {
+    return this.service.findAll(paginationDto);
   }
 
   @Get('me')
-  findMyReports(@Req() req: { user: { id: string } }) {
-    return this.service.findByReporter(req.user.id);
+  findMyReports(
+    @Req() req: { user: { id: string } },
+    @Query() paginationDto: FindReportsDto,
+  ) {
+    return this.service.findByReporter(req.user.id, paginationDto);
   }
 
   @Get(':id')
@@ -62,8 +67,6 @@ export class ReportAbuseController {
   update(
     @Param('id', new ParseObjectIdPipe()) id: string,
     @Body() payload: UpdateReportAbuseDto,
-  ) {
-    return this.service.update(id, payload);
     @AuditActor() audit: AuditContext,
   ) {
     return this.service.update(id, payload, audit);

--- a/src/report-abuse/report-abuse.module.ts
+++ b/src/report-abuse/report-abuse.module.ts
@@ -3,12 +3,14 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { ReportAbuseController } from './report-abuse.controller';
 import { ReportAbuseService } from './report-abuse.service';
 import { AbuseReport, AbuseReportSchema } from './schemas/report-abuse.schema';
+import { PaginationModule } from '../common/pagination/pagination.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: AbuseReport.name, schema: AbuseReportSchema },
     ]),
+    PaginationModule,
   ],
   controllers: [ReportAbuseController],
   providers: [ReportAbuseService],

--- a/src/report-abuse/report-abuse.service.ts
+++ b/src/report-abuse/report-abuse.service.ts
@@ -14,6 +14,8 @@ import {
   systemAuditContext,
 } from '../common/audit/audit-context';
 import { snapshot } from '../common/audit/audit-redaction';
+import { PaginationService } from '../common/pagination/pagination.service';
+import { FindReportsDto } from './dto/find-reports.dto';
 
 const TARGET_TYPE = 'abuse_report';
 
@@ -33,6 +35,7 @@ export class ReportAbuseService {
     @InjectModel(AbuseReport.name)
     private readonly abuseReportModel: Model<AbuseReportDocument>,
     private readonly auditService: AuditService,
+    private readonly paginationService: PaginationService,
   ) {}
 
   async create(
@@ -43,12 +46,19 @@ export class ReportAbuseService {
     return report.save();
   }
 
-  async findAll(): Promise<AbuseReport[]> {
-    return this.abuseReportModel.find().exec();
+  async findAll(paginationDto: FindReportsDto) {
+    return this.paginationService.paginate(
+      this.abuseReportModel,
+      paginationDto,
+    );
   }
 
-  async findByReporter(reporterUserId: string): Promise<AbuseReport[]> {
-    return this.abuseReportModel.find({ reporterUserId }).exec();
+  async findByReporter(reporterUserId: string, paginationDto: FindReportsDto) {
+    return this.paginationService.paginate(
+      this.abuseReportModel,
+      paginationDto,
+      { reporterUserId },
+    );
   }
 
   async findOne(id: string): Promise<AbuseReportDocument> {


### PR DESCRIPTION
## What does this PR do?

**Background**
This PR addresses the need for a standardized process for deprecating and retiring API endpoints. While the application uses URI-based versioning, it previously lacked a formal mechanism to communicate the lifecycle of an endpoint to clients, making it difficult to phase out old versions gracefully and manage breaking changes.

This implementation introduces a clear, automated policy using standard HTTP headers (Sunset and Link) to inform clients about endpoint deprecation, its planned removal date, and its successor.
## Related issue(s)

Closes #946 
Closes #947 
Closes #948 
Closes #949 


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How has this been tested?

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing

## Checklist

- [ ] Tests pass locally
- [ ] Swagger docs updated
- [ ] `.env.example` updated (if new env vars added)
